### PR TITLE
refactor: optimize API/CLI layer separation and add unit tests

### DIFF
--- a/.github/workflows/pyproc-pypi.yml
+++ b/.github/workflows/pyproc-pypi.yml
@@ -9,8 +9,28 @@ on:
       - v*
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -e ".[test]"
+
+    - name: Run unit tests
+      run: |
+        python -m pytest tests/test_lpse_unit.py tests/test_cli_unit.py tests/test_cache.py -v
+
   release-build:
     runs-on: ubuntu-latest
+    needs: test
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/pyproc-pypi.yml
+++ b/.github/workflows/pyproc-pypi.yml
@@ -12,10 +12,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.x'
 
@@ -32,10 +32,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.x'
 
@@ -51,7 +51,7 @@ jobs:
         python -m build
 
     - name: Upload distributions
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: release-dists
         path: dist/
@@ -68,7 +68,7 @@ jobs:
 
     steps:
     - name: Retrieve release distributions
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         name: release-dists
         path: dist/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,10 @@ jobs:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Test
+
+on:
+  push:
+    branches: [master]
+    tags: [v*]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -e ".[test]"
+
+    - name: Run unit tests
+      run: |
+        python -m pytest tests/test_lpse_unit.py tests/test_cli_unit.py tests/test_cache.py -v

--- a/plan/API_AND_CLI_WRAPPER_OPTIMIZATION_PLAN.md
+++ b/plan/API_AND_CLI_WRAPPER_OPTIMIZATION_PLAN.md
@@ -1,0 +1,1216 @@
+# API and CLI Wrapper Optimization Plan
+
+## 1. Executive Summary
+
+PyProc is a Python wrapper for Indonesia's government e-Procurement system (SPSE at `spse.inaproc.id`). It provides a low-level Python API (`Lpse` class) that scrapes SPSE web pages and a CLI bulk downloader that orchestrates index retrieval, detail downloading, and CSV/JSON export using a local SQLite database.
+
+The project works but has several structural issues:
+
+- **The CLI module (`cli.py`, 808 lines) is monolithic.** It contains argument parsing, SQLite schema management, index downloading, detail downloading, data export, signal handling, progress display, and the main entry point all in one file.
+- **Boundary violations exist between the API and CLI layers.** The CLI directly manipulates `requests` session internals, bypasses the `Lpse` class for host list downloads, and the `main()` function handles subcommands with raw `sys.argv` parsing instead of argparse.
+- **All tests are live integration tests with no mocks.** Every test hits real SPSE servers, making the test suite fragile, slow, and network-dependent.
+- **SQLite usage is embedded directly in CLI classes** with no separation between data access and download orchestration logic.
+- **Several dead/inconsistent code paths exist:** a hardcoded `workers = 1` ignoring the CLI argument, a `skip_spse_check` attribute referenced in tests but not on the `Lpse` class, and `LpseIndex.parse_detail()` returning inconsistent types (`{}` vs `None`).
+
+The most impactful improvements are: (1) extracting SQLite cache logic into a dedicated module, (2) adding mocked unit tests to enable safe refactoring, (3) cleaning up boundary violations, and (4) splitting the monolithic `cli.py` into focused modules.
+
+---
+
+## 2. Current Architecture
+
+### Package Layout
+
+```
+pyproc/
+    __init__.py          # Exports Lpse, JenisPengadaan, __version__
+    lpse.py              # 758 lines — API wrapper + all HTML parsers
+    cli.py               # 808 lines — CLI, downloader pipeline, SQLite cache, export
+    utils.py             # 91 lines — token parsing, host list download, version parsing
+    exceptions.py        # 18 lines — 5 exception classes
+    text.py              # 44 lines — UI strings and help text
+
+tests/
+    test_lpse.py         # 421 lines — API integration tests (live HTTP)
+    test_downloader.py   # 295 lines — CLI integration tests (live HTTP)
+```
+
+### How the API Wrapper Works
+
+`Lpse(instansi, timeout)` creates a `requests.Session`, builds a URL `https://spse.inaproc.id/{instansi}`, and provides:
+- `get_auth_token()` — extracts CSRF token from cookies or page JavaScript
+- `get_paket()` — POSTs to DataTables endpoint, returns JSON
+- `get_paket_tender()` / `get_paket_non_tender()` — convenience wrappers
+- `detil_paket_tender()` / `detil_paket_non_tender()` — returns `LpseDetil` objects
+
+`LpseDetil` and its parsers use BeautifulSoup/html5lib to scrape HTML detail pages. Retry logic is applied via `backoff.on_exception` decorators on `get_paket` and every detail method.
+
+### How the CLI Works
+
+`main()` in `cli.py` handles three paths:
+1. `pyproc daftarlpse` — calls `pyproc.utils.download_host()` (bypasses `Lpse`)
+2. `pyproc daftarhost [dir]` — calls `pyproc.utils.download_host_json()` (bypasses `Lpse`)
+3. Default — runs `Downloader` pipeline
+
+The `Downloader` pipeline per host:
+1. `IndexDownloader` — pages through `get_paket()`, inserts rows into SQLite `INDEX_PAKET`
+2. `DetailDownloader` — for each `STATUS=0` row, fetches detail via `detil_paket_*()` and `get_all_detil()`, updates SQLite
+3. `Exporter` — reads `STATUS=1` rows, writes CSV or JSON
+4. `QualityAssurance` — counts success/fail, writes `statistic.txt`
+
+### SQLite Schema
+
+Single table `INDEX_PAKET` with columns: `ROW_ID` (PK), `ID_PAKET`, `JENIS_PAKET`, `KATEGORI_TAHUN_ANGGARAN`, `STATUS` (0=pending, 1=done), `DETAIL` (JSON blob). Four indexes on `KATEGORI_TAHUN_ANGGARAN`, `ID_PAKET`, `JENIS_PAKET`, `STATUS`.
+
+### Configuration
+
+No config file system. All configuration via CLI argparse arguments with hardcoded defaults. API-layer constants (base URL, User-Agent, retry params) are hardcoded in `lpse.py`.
+
+---
+
+## 3. Layer Boundary Assessment
+
+### Good Existing Boundaries
+
+- **`Lpse` class is self-contained.** It owns its `requests.Session`, handles auth, requests, and response parsing internally. It can be used from Python code without the CLI.
+- **`exceptions.py` is properly separated.** Custom exceptions are in their own module.
+- **`text.py` isolates UI strings.** Help text and error messages are not scattered through logic.
+- **Parser classes follow a clean pattern.** `BaseLpseDetilParser` defines the interface; subclasses override `detil_path` and `parse_detil()`.
+
+### Boundary Violations
+
+| # | Violation | Location | Impact |
+|---|-----------|----------|--------|
+| 1 | CLI calls `pyproc.utils.download_host()` and `download_host_json()` directly, bypassing the `Lpse` class. These functions make raw `requests.get()` calls. | `cli.py:777-786`, `utils.py:23-85` | API-layer HTTP logic is duplicated outside the client class. |
+| 2 | CLI accesses `pyproc.JenisPengadaan` by string name lookup. | `cli.py:110-114` | CLI couples to specific enum names in the API layer. |
+| 3 | `utils.py` imports and uses `requests` directly for `get_all_host()` and `download_host_json()`. | `utils.py:24, 73` | HTTP transport leaks into a utility module. |
+| 4 | `check_new_version()` in CLI makes a raw `requests.get()` to PyPI. | `cli.py:36` | HTTP call in CLI layer with no error handling. |
+| 5 | SQLite schema definition, connection management, and queries are embedded in CLI classes (`IndexDownloader`, `DetailDownloader`, `Exporter`, `QualityAssurance`). | `cli.py:210-621` | Cache internals are inseparable from download orchestration. |
+| 6 | `print()` calls for progress output are inside `DetailDownloader.start()`. | `cli.py:496-507` | Progress display is coupled to download logic. |
+| 7 | `exit()` calls in `main()` and interactive menu. | `cli.py:643, 780, 787` | Process exit is scattered rather than centralized. |
+| 8 | `disable_warnings(InsecureRequestWarning)` is called at module import time in `cli.py`. | `cli.py:19` | Side effect on import; should be in the API layer or configurable. |
+
+### Duplicated Logic
+
+- **Host URL construction:** `Lpse.__init__` builds `https://spse.inaproc.id/{instansi}`, but `utils.py` independently fetches host lists from a different API (`satudata.inaproc.id`).
+- **HTTP request patterns:** Both `Lpse` and `utils.py` use `requests` with different timeout values, different error handling, and different session management.
+
+### Import Direction
+
+Import direction is correct: `cli.py` imports from `pyproc` (the API layer). There are no circular imports. However, `text.py` imports from `pyproc` (`__version__`), creating a mild coupling between UI strings and package metadata.
+
+---
+
+## 4. Key Findings
+
+### Finding 1: Monolithic CLI Module
+
+**Area:** Code Structure  
+**Severity:** High
+
+**Current Problem:**  
+`cli.py` is 808 lines containing 10 classes and the `main()` function. It handles argument parsing, SQLite schema, index downloading, detail downloading with threading, CSV/JSON export, quality assurance checks, signal handling, version checking, progress display, and interactive menus — all in one file.
+
+**Why It Matters:**  
+Changes to any one concern (e.g., SQLite schema) risk affecting unrelated concerns (e.g., export formatting). The file is difficult to navigate, test in isolation, or extend. New contributors face a high cognitive load.
+
+**Recommended Direction:**  
+Split into focused modules: `cache.py` (SQLite logic), `export.py` (CSV/JSON export), `downloader.py` (download orchestration), and keep `cli.py` as the thin entry point with argument parsing and `main()`.
+
+**Files/Modules Involved:**  
+`pyproc/cli.py`
+
+**Risk Level:** Medium — requires careful import management to avoid breaking the public entry point.
+
+---
+
+### Finding 2: SQLite Cache Embedded in CLI Classes
+
+**Area:** SQLite Cache  
+**Severity:** High
+
+**Current Problem:**  
+SQLite table creation (`CREATE TABLE INDEX_PAKET`), connection management, query execution, and row-to-object mapping are spread across `IndexDownloader`, `DetailDownloader`, `Exporter`, and `QualityAssurance`. The schema is defined as a string literal inside `get_index_db()`. Connection lifecycle is managed via `__del__` (garbage collection dependent).
+
+**Why It Matters:**  
+The cache cannot be tested independently. Schema changes require modifying the download orchestration code. The `__del__`-based cleanup is unreliable — Python does not guarantee `__del__` is called, and reference cycles can prevent it.
+
+**Recommended Direction:**  
+Extract a `CacheStore` class in a dedicated `cache.py` module that owns: connection lifecycle (context manager), schema creation, CRUD operations, and the row-to-`LpseIndex` factory. CLI classes should call `CacheStore` methods, not execute raw SQL.
+
+**Files/Modules Involved:**  
+`pyproc/cli.py` (lines 210-407, 510-621)
+
+**Risk Level:** Medium — schema must remain backward-compatible for `--resume` to work with existing `.idx` files.
+
+---
+
+### Finding 3: All Tests Are Live Integration Tests
+
+**Area:** Testing  
+**Severity:** High
+
+**Current Problem:**  
+Every test in `test_lpse.py` and `test_downloader.py` makes live HTTP requests to real SPSE servers. There are no mocked HTTP responses, no temporary SQLite databases, and no test fixtures for API responses.
+
+**Why It Matters:**  
+Tests fail when servers are down, slow, or change behavior. Tests cannot run in CI without network access. Test execution is slow. Edge cases (error responses, timeouts, malformed HTML) cannot be reliably tested.
+
+**Recommended Direction:**  
+Add a parallel set of unit tests using `unittest.mock` to patch `requests.Session.get/post`. Create fixture files with real HTML/JSON responses captured from the live API. Keep existing integration tests but mark them with a `@pytest.mark.integration` decorator so they can be skipped in fast CI runs.
+
+**Files/Modules Involved:**  
+`tests/test_lpse.py`, `tests/test_downloader.py`, new `tests/fixtures/` directory
+
+**Risk Level:** Low — adding tests does not change production code.
+
+---
+
+### Finding 4: Hardcoded Worker Count
+
+**Area:** CLI Wrapper  
+**Severity:** Medium
+
+**Current Problem:**  
+`DownloaderContext.__init__` sets `self.workers = 1` at line 99, ignoring the parsed `args.workers` value. The `--workers` CLI argument (default 8) is accepted by argparse but never used.
+
+**Why It Matters:**  
+Users believe they can control parallelism but cannot. The `--workers` help text is misleading. The threading infrastructure in `DetailDownloader` is built for multi-worker operation but is artificially constrained.
+
+**Recommended Direction:**  
+Either re-enable the workers argument (fix the thread safety issues first — see Finding 7) or remove the `--workers` argument from argparse to avoid confusion. If re-enabling, ensure SQLite reads in `get_index()` are thread-safe.
+
+**Files/Modules Involved:**  
+`pyproc/cli.py` (lines 99, 466, 692)
+
+**Risk Level:** Low — changing the default or removing the flag is a safe CLI behavior change.
+
+---
+
+### Finding 5: Inconsistent Error Return Types
+
+**Area:** API Wrapper  
+**Severity:** Medium
+
+**Current Problem:**  
+`LpseIndex.parse_detail()` returns `{}` on `TypeError` (when `detail` is `None`) but returns `None` for any other exception. Parser methods like `LpseDetilPemenangParser.parse_detil()` can return `None` (via bare `return` on `AttributeError`), a `list`, or `None` again at the end.
+
+**Why It Matters:**  
+Downstream code must handle both `dict` and `None` for the same field, leading to defensive checks scattered throughout. The `Exporter.to_csv()` method calls `item.get('pengumuman')` which fails if `item` is `None`.
+
+**Recommended Direction:**  
+Standardize return types: parsers should return `None` consistently on failure (never `{}`), and callers should check for `None` explicitly. Alternatively, return empty collections (`[]` for list parsers, `{}` for dict parsers) consistently.
+
+**Files/Modules Involved:**  
+`pyproc/lpse.py` (parser classes), `pyproc/cli.py` (LpseIndex, Exporter)
+
+**Risk Level:** Medium — changing return types may break downstream code that depends on current behavior.
+
+---
+
+### Finding 6: `skip_spse_check` Test Attribute Does Not Exist
+
+**Area:** Testing  
+**Severity:** Medium
+
+**Current Problem:**  
+In `test_lpse.py` line 202: `self.lpse.skip_spse_check = True` — this attribute does not exist on the `Lpse` class. The test `TestPaketNonTender.setUp()` sets a non-existent attribute, which silently succeeds in Python (dynamic attribute assignment) but has no effect.
+
+**Why It Matters:**  
+The test may be passing by accident. If the attribute was supposed to control behavior (e.g., skip a version/health check), that behavior is not being tested. If it was removed from `Lpse`, the test should have been updated.
+
+**Recommended Direction:**  
+Investigate whether `skip_spse_check` ever existed. If it was removed, remove the line from the test. If it was intended to control behavior, implement it properly or document why it's unnecessary.
+
+**Files/Modules Involved:**  
+`tests/test_lpse.py` (line 202)
+
+**Risk Level:** Low — test-only change.
+
+---
+
+### Finding 7: Thread Safety Concern with SQLite
+
+**Area:** Reliability  
+**Severity:** Medium
+
+**Current Problem:**  
+`DetailDownloader` uses `check_same_thread=False` on the SQLite connection and a `threading.Lock` for writes (`update_detail`), but reads in `get_index()` are not locked. If workers were re-enabled (>1), concurrent reads during writes could cause `sqlite3.OperationalError: database is locked`.
+
+**Why It Matters:**  
+The multi-worker path is broken by design. Even with `workers=1`, the `check_same_thread=False` flag is unnecessary and masks potential issues.
+
+**Recommended Direction:**  
+For now, keep `workers=1` and remove `check_same_thread=False`. If multi-worker support is desired later, either use WAL mode with proper locking, or use a connection-per-thread pattern.
+
+**Files/Modules Involved:**  
+`pyproc/cli.py` (lines 257, 448-455, 379-387)
+
+**Risk Level:** Low — removing `check_same_thread=False` with `workers=1` is safe.
+
+---
+
+### Finding 8: `utils.py` Makes Raw HTTP Calls
+
+**Area:** API Wrapper  
+**Severity:** Medium
+
+**Current Problem:**  
+`utils.py` contains `get_all_host()` and `download_host_json()` which make direct `requests.get()` calls to external APIs (`satudata.inaproc.id` and GitHub Gist). These bypass the `Lpse` class entirely and have no retry logic, no session management, and minimal error handling.
+
+**Why It Matters:**  
+HTTP transport is scattered across modules. Error handling is inconsistent (some functions raise, others silently fail). The `download_host()` function takes a `logging` module as a parameter instead of using the standard `logging.getLogger()` pattern.
+
+**Recommended Direction:**  
+Either: (a) move these HTTP calls into a proper client class with consistent retry/error handling, or (b) keep them as standalone utilities but add consistent error handling and use `logging.getLogger(__name__)` instead of passing `logging` as a parameter.
+
+**Files/Modules Involved:**  
+`pyproc/utils.py`
+
+**Risk Level:** Low — these are auxiliary functions, not core API.
+
+---
+
+### Finding 9: No Type Hints
+
+**Area:** Code Structure  
+**Severity:** Low
+
+**Current Problem:**  
+The entire codebase has no type hints. Function signatures, return types, and data structures are documented only in docstrings (and many functions lack docstrings entirely).
+
+**Why It Matters:**  
+IDE autocomplete is limited. Static analysis tools cannot catch type errors. New contributors must read implementation to understand data shapes.
+
+**Recommended Direction:**  
+Add type hints incrementally, starting with the public API (`Lpse` methods, `BaseLpseDetil` attributes) and CLI entry points. Use `from __future__ import annotations` for Python 3.9 compatibility.
+
+**Files/Modules Involved:**  
+All `.py` files
+
+**Risk Level:** Low — type hints are additive and do not change runtime behavior.
+
+---
+
+### Finding 10: `__del__`-Based Resource Cleanup
+
+**Area:** Reliability  
+**Severity:** Medium
+
+**Current Problem:**  
+Both `Lpse.__del__()` (line 237) and `IndexDownloader.__del__()` (line 396) rely on garbage collection to close resources (HTTP session, SQLite connection). Python does not guarantee `__del__` is called, and reference cycles can prevent it entirely.
+
+**Why It Matters:**  
+SQLite connections may leak. HTTP sessions may not be closed properly. In long-running processes or when exceptions occur, resources may accumulate.
+
+**Recommended Direction:**  
+Implement context managers (`__enter__`/`__exit__`) for both `Lpse` and `IndexDownloader`. Keep `__del__` as a safety net but do not rely on it. Use `with` statements in the CLI.
+
+**Files/Modules Involved:**  
+`pyproc/lpse.py` (Lpse class), `pyproc/cli.py` (IndexDownloader class)
+
+**Risk Level:** Low — adding context managers is backward-compatible.
+
+---
+
+### Finding 11: `main()` Handles Subcommands with Raw sys.argv
+
+**Area:** CLI Wrapper  
+**Severity:** Low
+
+**Current Problem:**  
+`main()` checks `sys.argv[1]` directly for `daftarlpse` and `daftarhost` subcommands before falling through to argparse. The subcommands bypass argparse entirely, meaning they don't support `--help`, have no argument validation, and `daftarhost` parses `sys.argv[2]` manually.
+
+**Why It Matters:**  
+Subcommand behavior is inconsistent with the main command. Users cannot get help for subcommands. Adding new subcommands requires modifying the raw argv parsing.
+
+**Recommended Direction:**  
+Convert to argparse subparsers: `pyproc download [args]`, `pyproc daftarlpse`, `pyproc daftarhost [dir]`. This unifies argument handling and enables `pyproc daftarhost --help`.
+
+**Files/Modules Involved:**  
+`pyproc/cli.py` (main function, lines 769-807)
+
+**Risk Level:** Medium — changes CLI invocation syntax. Must preserve backward compatibility (e.g., default to `download` when no subcommand is given).
+
+---
+
+### Finding 12: Disabled SSL Verification
+
+**Area:** Reliability  
+**Severity:** Low
+
+**Current Problem:**  
+`Lpse.__init__` sets `self.session.verify = False` and `cli.py` suppresses `InsecureRequestWarning` at import time. This disables SSL certificate verification for all requests.
+
+**Why It Matters:**  
+This is likely necessary because the SPSE server may have misconfigured certificates. However, it should be documented and ideally configurable rather than silently disabled.
+
+**Recommended Direction:**  
+Add a `verify` parameter to `Lpse.__init__` defaulting to `False` (preserving current behavior), with a comment explaining why. Move the warning suppression into the API layer.
+
+**Files/Modules Involved:**  
+`pyproc/lpse.py` (line 38), `pyproc/cli.py` (lines 16-19)
+
+**Risk Level:** Low — additive parameter with backward-compatible default.
+
+---
+
+### Finding 13: pyproject.toml Classifiers Mismatch
+
+**Area:** DevEx  
+**Severity:** Low
+
+**Current Problem:**  
+The `pyproject.toml` lists `Programming Language :: Python :: 3.7` in classifiers but `requires-python = ">=3.9"`. The classifier is stale.
+
+**Why It Matters:**  
+Users may be confused about supported Python versions. PyPI displays the classifier prominently.
+
+**Recommended Direction:**  
+Update classifiers to match `requires-python`. Add `3.9`, `3.10`, `3.11`, `3.12` classifiers.
+
+**Files/Modules Involved:**  
+`pyproject.toml`
+
+**Risk Level:** Low — metadata-only change.
+
+---
+
+## 5. Optimization Roadmap
+
+### Phase 0 — Safety and Baseline
+
+**Goal:** Establish a safety net before any refactoring.
+
+- Document current `Lpse` public API signatures and return types
+- Document current CLI commands, arguments, and exit codes
+- Capture sample SPSE HTML responses as test fixtures
+- Add mocked unit tests for `Lpse.get_paket()` and `Lpse.get_auth_token()`
+- Add mocked unit tests for `IndexDownloader` with a temporary SQLite file
+- Add mocked unit tests for `Exporter` CSV/JSON output
+- Identify and fix the `skip_spse_check` test issue
+- Verify all existing tests still pass
+
+### Phase 1 — Layer Boundary Cleanup
+
+**Goal:** Ensure CLI only calls public API wrapper methods; no direct HTTP or raw SQL from the wrong layer.
+
+- Move `disable_warnings(InsecureRequestWarning)` into `Lpse.__init__` or a transport config
+- Replace `pyproc.utils.download_host()` and `download_host_json()` calls in `main()` with calls through a proper client method or keep them as utilities with consistent error handling
+- Replace `exit()` calls in `main()` with `sys.exit()` and centralize exit points
+- Ensure `DownloaderContext.kategori` uses a safe lookup that does not depend on exact enum names
+- Remove `print()` from `DetailDownloader.start()` and use `logging` consistently
+- Move `check_new_version()` error handling to catch network failures gracefully
+
+### Phase 2 — SQLite Cache Extraction
+
+**Goal:** Separate SQLite logic from download orchestration.
+
+- Create `pyproc/cache.py` with a `CacheStore` class
+- Move schema creation, connection management, CRUD operations into `CacheStore`
+- Implement context manager for connection lifecycle
+- Keep the same `INDEX_PAKET` schema for backward compatibility
+- Update `IndexDownloader`, `DetailDownloader`, `Exporter`, `QualityAssurance` to use `CacheStore`
+- Add unit tests for `CacheStore` using temporary SQLite files
+
+### Phase 3 — CLI Module Split
+
+**Goal:** Break `cli.py` into focused modules without changing public behavior.
+
+- Create `pyproc/downloader.py` for `IndexDownloader`, `DetailDownloader`, `LpseIndex`, `LpseHost`, `DownloaderContext`
+- Create `pyproc/export.py` for `Exporter`
+- Keep `cli.py` as the thin entry point: `main()`, `Downloader`, argument parsing, signal handling
+- Preserve the `pyproc.cli:main` entry point
+- Update imports throughout
+
+### Phase 4 — Low-Level API Wrapper Improvement
+
+**Goal:** Improve the `Lpse` class for independent Python use.
+
+- Add `verify` parameter to `Lpse.__init__` (default `False`, documented)
+- Add context manager support to `Lpse`
+- Standardize parser return types (consistent `None` or empty collection on failure)
+- Add type hints to public API methods
+- Consolidate retry configuration into a class-level constant or parameter
+- Document the public API in docstrings
+
+### Phase 5 — CLI Experience Improvement
+
+**Goal:** Improve usability without breaking existing commands.
+
+- Convert `main()` to use argparse subparsers (with backward-compatible default)
+- Fix or remove `--workers` argument
+- Standardize exit codes (0=success, 1=error, 2=usage error)
+- Add `--no-ssl-verify` flag (defaulting to current behavior of no verification)
+- Improve error messages for common failures (host not found, network timeout)
+
+### Phase 6 — Packaging and Developer Experience
+
+**Goal:** Clean up project metadata and developer workflow.
+
+- Fix `pyproject.toml` Python version classifiers
+- Add `[project.optional-dependencies]` for dev/test dependencies (`pytest`, `responses` or `requests-mock`)
+- Add `conftest.py` with shared fixtures
+- Update Makefile test targets
+- Add brief README sections for: Python API usage, CLI usage, development setup
+
+---
+
+## 6. Implementation Tasks for Small Agents
+
+### Task 1: Capture SPSE Response Fixtures
+
+**Goal:** Create test fixture files with real SPSE HTML/JSON responses for mocked testing.
+
+**Context:** All current tests hit live servers. We need fixture files to enable offline unit tests.
+
+**Scope:** New `tests/fixtures/` directory, no production code changes.
+
+**Implementation Instructions:**
+1. Create `tests/fixtures/` directory
+2. Run each API call once and capture the response:
+   - `GET /{instansi}/lelang` — HTML page with auth token
+   - `POST /dt/lelang` — JSON DataTables response
+   - `GET /lelang/{id}/pengumumanlelang` — HTML detail page
+   - `GET /lelang/{id}/peserta` — HTML participants page
+   - `GET /evaluasi/{id}/hasil` — HTML evaluation results page
+   - `GET /evaluasi/{id}/pemenang` — HTML winner page
+   - `GET /lelang/{id}/jadwal` — HTML schedule page
+3. Save each as a `.html` or `.json` file in `tests/fixtures/`
+4. Add a `README.md` in fixtures explaining how to refresh them
+
+**Do Not Change:** Production code, existing tests.
+
+**Acceptance Criteria:**
+- [ ] Fixture directory exists with at least 7 response files
+- [ ] Each file contains valid HTML or JSON
+- [ ] Fixture README explains refresh procedure
+
+**Suggested Tests:** N/A (this is test infrastructure).
+
+**Risk:** Low
+
+**Dependencies:** None
+
+---
+
+### Task 2: Add Mocked Unit Tests for Lpse API
+
+**Goal:** Add unit tests for `Lpse` that do not require network access.
+
+**Context:** Current tests are all live integration tests. Mocked tests enable safe refactoring.
+
+**Scope:** New `tests/test_lpse_unit.py`, no production code changes.
+
+**Implementation Instructions:**
+1. Create `tests/test_lpse_unit.py`
+2. Use `unittest.mock.patch` to mock `requests.Session.get` and `requests.Session.post`
+3. Load fixture files from `tests/fixtures/`
+4. Test cases:
+   - `test_get_auth_token_from_cookies` — mock response with `SPSE_SESSION` cookie containing `___AT=xxx&`
+   - `test_get_auth_token_from_page` — mock response without cookie, verify JS parsing fallback
+   - `test_get_paket_returns_dict` — mock POST response with JSON, verify dict return
+   - `test_get_paket_data_only_returns_list` — verify `data_only=True` returns list
+   - `test_get_paket_error_raises` — mock 404 response, verify `LpseServerExceptions`
+   - `test_get_paket_spse_error_text` — mock 200 with error text in body, verify exception
+   - `test_detil_paket_tender_returns_lpse_detil` — verify return type
+   - `test_parser_pengumuman` — feed fixture HTML, verify parsed dict structure
+   - `test_parser_peserta` — feed fixture HTML, verify list of dicts
+   - `test_parser_pemenang_empty_table` — verify `None` return on missing table
+
+**Do Not Change:** Production code.
+
+**Acceptance Criteria:**
+- [ ] All tests pass without network access
+- [ ] Tests cover auth token, search, detail parsing, and error paths
+- [ ] Tests use fixture files, not live HTTP
+
+**Suggested Tests:** Run with `pytest tests/test_lpse_unit.py -v`
+
+**Risk:** Low
+
+**Dependencies:** Task 1
+
+---
+
+### Task 3: Add Mocked Unit Tests for CLI Components
+
+**Goal:** Add unit tests for CLI argument parsing, context creation, and export that do not require network access.
+
+**Context:** Current CLI tests hit live servers. Need offline tests for safe refactoring.
+
+**Scope:** New `tests/test_cli_unit.py`, no production code changes.
+
+**Implementation Instructions:**
+1. Create `tests/test_cli_unit.py`
+2. Test `DownloaderContext` creation with various argument combinations
+3. Test `LpseHost` parsing (valid, invalid, with filename, without filename)
+4. Test `DownloaderContext.parse_tahun_anggaran()` edge cases (single, range, comma-separated, "all", invalid)
+5. Test `Exporter.to_csv()` and `Exporter.to_json()` with mock data in a temporary SQLite DB
+6. Test `QualityAssurance.check()` with mock data
+7. Test `LpseIndex` creation and `parse_detail()` with `None`, valid JSON, and invalid input
+
+**Do Not Change:** Production code.
+
+**Acceptance Criteria:**
+- [ ] All tests pass without network access
+- [ ] Tests cover argument parsing, host parsing, year parsing, export, and QA
+- [ ] Tests use temporary SQLite databases, not live ones
+
+**Suggested Tests:** Run with `pytest tests/test_cli_unit.py -v`
+
+**Risk:** Low
+
+**Dependencies:** None
+
+---
+
+### Task 4: Fix Known Bugs and Inconsistencies
+
+**Goal:** Fix the `skip_spse_check` test attribute, inconsistent `parse_detail()` return type, and stale pyproject.toml classifiers.
+
+**Context:** These are small bugs that should be fixed before refactoring to establish a clean baseline.
+
+**Scope:** `tests/test_lpse.py`, `pyproc/lpse.py` (LpseIndex), `pyproject.toml`
+
+**Implementation Instructions:**
+1. In `tests/test_lpse.py` line 202: remove `self.lpse.skip_spse_check = True` (the attribute has no effect)
+2. In `pyproc/cli.py` `LpseIndex.parse_detail()`: change the `TypeError` handler to return `None` instead of `{}`, making it consistent with the general exception path. Update any code that assumes `{}` (check `Exporter` and `DetailDownloader`).
+3. In `pyproject.toml`: update classifiers to replace `Programming Language :: Python :: 3.7` with `3.9`, `3.10`, `3.11`, `3.12`
+
+**Do Not Change:** Public API behavior, CLI commands, `Lpse` class interface.
+
+**Acceptance Criteria:**
+- [ ] `self.lpse.skip_spse_check = True` removed from test
+- [ ] `LpseIndex.parse_detail()` returns `None` consistently on error
+- [ ] `pyproject.toml` classifiers match `requires-python = ">=3.9"`
+- [ ] Existing tests still pass
+
+**Suggested Tests:** Run full test suite.
+
+**Risk:** Low
+
+**Dependencies:** None
+
+---
+
+### Task 5: Extract SQLite Cache into `pyproc/cache.py`
+
+**Goal:** Create a `CacheStore` class that owns all SQLite operations, separate from download orchestration.
+
+**Context:** SQLite logic is currently embedded in `IndexDownloader`, `DetailDownloader`, `Exporter`, and `QualityAssurance`. Extracting it enables independent testing and cleaner refactoring.
+
+**Scope:** New `pyproc/cache.py`, modify `pyproc/cli.py`
+
+**Implementation Instructions:**
+1. Create `pyproc/cache.py` with class `CacheStore`
+2. `CacheStore.__init__(self, db_path: Path)` — stores path
+3. `CacheStore.__enter__` / `__exit__` — open/close connection
+4. `CacheStore.create_schema()` — execute CREATE TABLE and CREATE INDEX statements
+5. `CacheStore.drop_schema()` — execute DROP TABLE IF EXISTS
+6. `CacheStore.insert_rows(rows)` — executemany INSERT OR IGNORE
+7. `CacheStore.get_pending()` — SELECT WHERE STATUS=0, yield `LpseIndex` objects
+8. `CacheStore.update_detail(row_id, detail_json)` — UPDATE SET DETAIL=?, STATUS=1
+9. `CacheStore.get_completed()` — SELECT WHERE STATUS=1
+10. `CacheStore.count_by_status()` — returns `{0: fail_count, 1: success_count}`
+11. `CacheStore.has_rows()` — returns bool (for resume check)
+12. Move `index_factory` static method into `CacheStore` or keep it on `LpseIndex`
+13. Update `IndexDownloader`, `DetailDownloader`, `Exporter`, `QualityAssurance` to accept a `CacheStore` instance
+14. Remove raw SQL from CLI classes
+
+**Do Not Change:** SQLite schema (table name, columns, indexes must remain identical for `--resume` compatibility), public CLI behavior, `Lpse` class.
+
+**Acceptance Criteria:**
+- [ ] `pyproc/cache.py` exists with `CacheStore` class
+- [ ] `CacheStore` uses context manager for connection lifecycle
+- [ ] No raw SQL remains in `IndexDownloader`, `DetailDownloader`, `Exporter`, or `QualityAssurance`
+- [ ] Existing `.idx` files work with `--resume`
+- [ ] All existing tests pass
+
+**Suggested Tests:**
+- `test_cache_create_schema` — verify table and indexes created
+- `test_cache_insert_and_get_pending` — insert rows, verify pending retrieval
+- `test_cache_update_detail` — update row, verify status change
+- `test_cache_count_by_status` — verify counts
+- `test_cache_context_manager` — verify connection cleanup
+
+**Risk:** Medium — must preserve schema compatibility for `--resume`.
+
+**Dependencies:** Task 3 (mocked CLI tests provide safety net)
+
+---
+
+### Task 6: Move `disable_warnings` and SSL Config to API Layer
+
+**Goal:** Consolidate SSL-related configuration in the API layer.
+
+**Context:** `cli.py` suppresses `InsecureRequestWarning` at import time. This should be in the API layer where SSL is actually disabled.
+
+**Scope:** `pyproc/lpse.py`, `pyproc/cli.py`
+
+**Implementation Instructions:**
+1. In `Lpse.__init__`, after setting `self.session.verify = False`:
+   ```python
+   from urllib3.exceptions import InsecureRequestWarning
+   from urllib3 import disable_warnings
+   disable_warnings(InsecureRequestWarning)
+   ```
+2. Remove the same imports and call from `cli.py` lines 16-19
+3. Add a `verify` parameter to `Lpse.__init__` defaulting to `False`:
+   ```python
+   def __init__(self, instansi, timeout=10, verify=False):
+       self.session = requests.session()
+       self.session.verify = verify
+   ```
+
+**Do Not Change:** Default behavior (SSL verification stays disabled by default).
+
+**Acceptance Criteria:**
+- [ ] `InsecureRequestWarning` suppression is in `lpse.py`, not `cli.py`
+- [ ] `Lpse` accepts `verify` parameter
+- [ ] Default behavior unchanged (no verification)
+- [ ] Tests pass
+
+**Suggested Tests:** `test_lpse_verify_parameter_default_false`
+
+**Risk:** Low
+
+**Dependencies:** None
+
+---
+
+### Task 7: Add Context Manager to `Lpse` and `IndexDownloader`
+
+**Goal:** Enable `with` statement usage for proper resource cleanup.
+
+**Context:** Both classes rely on `__del__` for cleanup, which is unreliable.
+
+**Scope:** `pyproc/lpse.py`, `pyproc/cli.py`
+
+**Implementation Instructions:**
+1. Add to `Lpse`:
+   ```python
+   def __enter__(self):
+       return self
+
+   def __exit__(self, exc_type, exc_val, exc_tb):
+       self.session.close()
+       return False
+   ```
+2. Add to `IndexDownloader`:
+   ```python
+   def __enter__(self):
+       return self
+
+   def __exit__(self, exc_type, exc_val, exc_tb):
+       if self.db:
+           self.db.close()
+       return False
+   ```
+3. Keep existing `__del__` methods as safety nets
+4. Update `Downloader.start()` to use `with IndexDownloader(...)` if practical
+
+**Do Not Change:** Public API behavior, CLI behavior.
+
+**Acceptance Criteria:**
+- [ ] `Lpse` and `IndexDownloader` support `with` statement
+- [ ] `__del__` still exists as fallback
+- [ ] Tests pass
+
+**Suggested Tests:** `test_lpse_context_manager`, `test_index_downloader_context_manager`
+
+**Risk:** Low
+
+**Dependencies:** None
+
+---
+
+### Task 8: Convert `main()` to Argparse Subparsers
+
+**Goal:** Unify argument handling for all subcommands under argparse.
+
+**Context:** `daftarlpse` and `daftarhost` subcommands bypass argparse, making them inconsistent and lacking `--help` support.
+
+**Scope:** `pyproc/cli.py` (main function)
+
+**Implementation Instructions:**
+1. Restructure argparse to use subparsers:
+   - `pyproc download [args]` — current default behavior
+   - `pyproc daftarlpse` — export host list as CSV
+   - `pyproc daftarhost [directory]` — export host list as JSON
+2. For backward compatibility: if no recognized subcommand is given, treat all args as `download` args (detect by checking if first arg starts with `-` or is a known host pattern)
+3. Add `--help` support for each subcommand
+4. Replace `exit(0)` with `sys.exit(0)`
+
+**Do Not Change:** Existing CLI behavior when invoked without subcommands (backward compatible).
+
+**Acceptance Criteria:**
+- [ ] `pyproc download --help` works
+- [ ] `pyproc daftarlpse` works
+- [ ] `pyproc daftarhost --help` works
+- [ ] `pyproc kemenkeu --tahun-anggaran 2025` still works (backward compatible)
+- [ ] Tests pass
+
+**Suggested Tests:** `test_main_download_subcommand`, `test_main_daftarlpse_subcommand`, `test_main_backward_compat`
+
+**Risk:** Medium — must preserve backward compatibility for existing users.
+
+**Dependencies:** None
+
+---
+
+### Task 9: Fix or Remove `--workers` Argument
+
+**Goal:** Resolve the discrepancy between the `--workers` CLI argument (default 8) and the hardcoded `self.workers = 1`.
+
+**Context:** The argument is accepted but ignored, misleading users.
+
+**Scope:** `pyproc/cli.py`
+
+**Implementation Instructions:**
+1. Option A (recommended): Remove `--workers` from argparse and remove the `workers` attribute from `DownloaderContext`. Keep `workers=1` as a constant. This avoids the thread safety issues.
+2. Option B: Re-enable workers by changing `self.workers = 1` to `self.workers = args.workers`, but then fix thread safety: add locking to `get_index()` reads, or use WAL mode, or use a connection-per-thread pattern.
+
+**Do Not Change:** Detail download behavior (single-threaded remains default).
+
+**Acceptance Criteria:**
+- [ ] `--workers` argument either works correctly or is removed
+- [ ] No misleading CLI help text
+- [ ] Tests pass
+
+**Suggested Tests:** If removing: `test_workers_argument_not_in_help`. If fixing: `test_multi_worker_download`.
+
+**Risk:** Low (removing) or Medium (fixing).
+
+**Dependencies:** Task 5 (cache extraction makes thread safety easier to reason about)
+
+---
+
+### Task 10: Standardize Error Handling in `utils.py`
+
+**Goal:** Make `utils.py` functions use consistent error handling and logging patterns.
+
+**Context:** `download_host()` takes `logging` as a parameter (anti-pattern). `get_all_host()` has no error handling. `download_host_json()` raises on HTTP error but `get_all_host()` does not.
+
+**Scope:** `pyproc/utils.py`
+
+**Implementation Instructions:**
+1. Replace `def download_host(logging, ...)` with `def download_host(...)` using `logger = logging.getLogger(__name__)` at module level
+2. Same for `download_host_json()`
+3. Add try/except around `get_all_host()` HTTP call with a meaningful error message
+4. Add timeout to `get_all_host()` (already has `timeout=10`, verify it's present)
+5. Add retry logic to `download_host_json()` or document that it has no retries
+
+**Do Not Change:** Function signatures (except removing `logging` parameter — this is a breaking change for direct callers, but these are internal functions).
+
+**Acceptance Criteria:**
+- [ ] `utils.py` uses `logging.getLogger(__name__)` instead of passed `logging` parameter
+- [ ] HTTP calls have consistent error handling
+- [ ] Tests pass (update `test_downloader.py` and `test_lpse.py` if they call these functions)
+
+**Suggested Tests:** `test_download_host_json_error_handling`, `test_get_all_host_timeout`
+
+**Risk:** Medium — removing `logging` parameter is a breaking change for any external callers.
+
+**Dependencies:** None
+
+---
+
+### Task 11: Add Type Hints to Public API
+
+**Goal:** Add type hints to `Lpse` public methods and `BaseLpseDetil` attributes.
+
+**Context:** No type hints exist in the codebase. Adding them to the public API improves IDE support and documentation.
+
+**Scope:** `pyproc/lpse.py`, `pyproc/exceptions.py`
+
+**Implementation Instructions:**
+1. Add `from __future__ import annotations` at the top of `lpse.py`
+2. Add type hints to `Lpse.__init__`, `get_auth_token`, `get_paket`, `get_paket_tender`, `get_paket_non_tender`, `detil_paket_tender`, `detil_paket_non_tender`
+3. Add type hints to `BaseLpseDetil` attributes and `get_all_detil`, `todict`
+4. Add type hints to `BaseLpseDetilParser.get_detil` and `parse_detil`
+5. Add type hints to exception classes (they have no methods, so this is just ensuring `__init__` signatures are typed)
+
+**Do Not Change:** Runtime behavior.
+
+**Acceptance Criteria:**
+- [ ] All public `Lpse` methods have type hints
+- [ ] `BaseLpseDetil` attributes have type hints
+- [ ] `from __future__ import annotations` is used for Python 3.9 compatibility
+- [ ] Tests pass
+
+**Suggested Tests:** N/A (type hints don't change behavior; run existing tests to verify no syntax errors).
+
+**Risk:** Low
+
+**Dependencies:** None
+
+---
+
+### Task 12: Update pyproject.toml and Dev Dependencies
+
+**Goal:** Fix classifiers and declare dev dependencies properly.
+
+**Context:** Classifiers list Python 3.7 but `requires-python` is `>=3.9`. Dev dependencies are not declared.
+
+**Scope:** `pyproject.toml`, `Makefile`
+
+**Implementation Instructions:**
+1. Update classifiers to remove `3.7`, add `3.9`, `3.10`, `3.11`, `3.12`
+2. Add `[project.optional-dependencies]` section:
+   ```toml
+   [project.optional-dependencies]
+   test = ["pytest"]
+   ```
+3. Update Makefile `install` target to use `pip install -e ".[test]"`
+
+**Do Not Change:** Runtime dependencies, package behavior.
+
+**Acceptance Criteria:**
+- [ ] Classifiers match `requires-python`
+- [ ] `pip install -e ".[test]"` installs pytest
+- [ ] Makefile works
+
+**Suggested Tests:** N/A
+
+**Risk:** Low
+
+**Dependencies:** None
+
+---
+
+## 7. Proposed Lightweight Project Structure
+
+### Current Structure
+
+```
+pyproc/
+    __init__.py
+    lpse.py              # API wrapper + all parsers (758 lines)
+    cli.py               # Everything else (808 lines)
+    utils.py
+    exceptions.py
+    text.py
+```
+
+### Proposed Structure
+
+```
+pyproc/
+    __init__.py          # Exports Lpse, JenisPengadaan, __version__ (unchanged)
+    lpse.py              # API wrapper + parsers (unchanged for now)
+    cache.py             # NEW — CacheStore class for SQLite operations
+    cli.py               # Slimmed down — main(), Downloader, argparse only
+    downloader.py        # NEW — IndexDownloader, DetailDownloader, LpseIndex, LpseHost, DownloaderContext
+    export.py            # NEW — Exporter class
+    utils.py             # Token parsing, host list download (cleaned up)
+    exceptions.py        # Unchanged
+    text.py              # Unchanged
+
+tests/
+    conftest.py          # NEW — shared fixtures
+    fixtures/            # NEW — captured HTML/JSON responses
+    test_lpse.py         # Existing integration tests (unchanged)
+    test_downloader.py   # Existing integration tests (unchanged)
+    test_lpse_unit.py    # NEW — mocked API tests
+    test_cli_unit.py     # NEW — mocked CLI tests
+    test_cache.py        # NEW — CacheStore tests
+```
+
+### What Moves Where
+
+| Current Location | New Location | Reason |
+|---|---|---|
+| `IndexDownloader` class | `pyproc/downloader.py` | Download orchestration, not CLI entry point |
+| `DetailDownloader` class | `pyproc/downloader.py` | Download orchestration |
+| `LpseIndex` class | `pyproc/downloader.py` | Data class used by downloaders |
+| `LpseHost` class | `pyproc/downloader.py` | Host parsing used by downloaders |
+| `DownloaderContext` class | `pyproc/downloader.py` | Context used by downloaders |
+| `Exporter` class | `pyproc/export.py` | Export logic, independent of download |
+| `QualityAssurance` class | `pyproc/downloader.py` or `pyproc/export.py` | QA is part of export pipeline |
+| SQLite schema/queries | `pyproc/cache.py` | Data access layer |
+| `Downloader` class | `pyproc/cli.py` (stays) | CLI orchestration |
+| `main()` function | `pyproc/cli.py` (stays) | Entry point |
+| `IWillFindYouAndIWillKillYou` | `pyproc/cli.py` (stays) | Signal handling is CLI concern |
+| `set_up_log()` | `pyproc/cli.py` (stays) | Logging config is CLI concern |
+| `check_new_version()` | `pyproc/cli.py` (stays) | Version check is CLI concern |
+
+### Migration Steps
+
+1. **Add tests first** (Tasks 1-3) — safety net
+2. **Fix bugs** (Task 4) — clean baseline
+3. **Extract `cache.py`** (Task 5) — biggest structural win
+4. **Extract `downloader.py`** — move classes, update imports in `cli.py`
+5. **Extract `export.py`** — move `Exporter`, update imports
+6. **Verify** — run all tests after each extraction
+
+### How to Avoid Breaking Imports
+
+- Keep `pyproc.cli:main` as the entry point
+- If external code imports from `pyproc.cli` (e.g., `from pyproc.cli import IndexDownloader`), add re-exports in `cli.py`:
+  ```python
+  from .downloader import IndexDownloader, DetailDownloader  # backward compat
+  ```
+- The `tests/test_downloader.py` uses `from pyproc.cli import *` — this will need updating after the split.
+
+### What Should NOT Be Abstracted Yet
+
+- Do not create abstract base classes for the downloaders
+- Do not introduce dependency injection for `Lpse` (the current direct instantiation is fine)
+- Do not split `lpse.py` further (parsers are tightly coupled to the API class)
+- Do not create a configuration file system (CLI args are sufficient)
+
+---
+
+## 8. Low-Level API Wrapper Plan
+
+### Public API Design
+
+The current `Lpse` API is reasonable. Improvements:
+
+1. **Add `verify` parameter** to `__init__` (default `False`) — documented, configurable
+2. **Add context manager** — `__enter__`/`__exit__` for session cleanup
+3. **Standardize return types** — parsers return `None` on failure (not mixed `{}`/`None`)
+4. **Add type hints** to all public methods
+
+### Request/Response Handling
+
+Current handling is adequate:
+- `requests.Session` with persistent cookies — correct for SPSE's CSRF token flow
+- `check_error()` static method checks status codes and error text — good
+- DataTables-style POST parameters are constructed correctly
+
+Improvements:
+- Move the User-Agent string to a class constant
+- Document why SSL verification is disabled
+
+### Error Model
+
+Current exceptions in `exceptions.py`:
+- `LpseVersionException` — unused in current code
+- `LpseHostExceptions` — unused in current code
+- `LpseServerExceptions` — used for API errors
+- `LpseAuthTokenNotFound` — unused in current code
+- `DownloaderContextException` — CLI-specific, should move to CLI layer
+
+Improvements:
+- Remove unused exceptions or document their intended use
+- Move `DownloaderContextException` to the CLI/downloader module
+- Consider adding `LpseConnectionError` for network failures (wrapping `requests.exceptions.ConnectionError`)
+
+### Retry/Timeout/Rate-Limit Behavior
+
+Current: `backoff.on_exception` with Fibonacci backoff, `max_tries=3`, `jitter=None`, applied via decorators.
+
+This is adequate for the SPSE API. Improvements:
+- Make retry parameters configurable on `Lpse.__init__` (optional — only if users request it)
+- Add `on_backoff` callback for logging retry attempts
+
+### Backward Compatibility Notes
+
+- `Lpse(instansi, timeout=10)` signature must not change
+- `get_paket()` return shape (dict with `data`, `recordsTotal`, `recordsFiltered`) must not change
+- `detil_paket_tender()` / `detil_paket_non_tender()` must continue returning `LpseDetil` / `LpseDetilNonTender`
+- `BaseLpseDetil.todict()` must continue returning a dict without `_lpse`
+- `By` and `JenisPengadaan` enums must not change values
+
+---
+
+## 9. CLI Wrapper Plan
+
+### Command Structure
+
+Current: `pyproc [lpse_host] [options]` with special-case `daftarlpse` and `daftarhost`.
+
+Proposed (with backward compatibility):
+```
+pyproc [lpse_host] [options]          # backward compatible default (treated as "download")
+pyproc download [lpse_host] [options] # explicit download subcommand
+pyproc daftarlpse                     # export host list CSV
+pyproc daftarhost [directory]         # export host list JSON
+```
+
+### Argument Naming Consistency
+
+Current arguments are consistent. Minor improvements:
+- `--sep` alias for `--separator` is already present (good)
+- Consider adding `--output` or `-o` as alias for `--output-format` (already `-o`)
+- `--tahun-anggaran` vs `--tahun` — the test at line 238 uses `--tahun` but argparse defines `--tahun-anggaran`. Verify if `--tahun` works as an abbreviation.
+
+### Output Formatting
+
+Current: CSV and JSON output via `Exporter`. Progress via `print()` in `DetailDownloader`.
+
+Improvements:
+- Move progress display to use `logging.info()` consistently (already partially done)
+- Ensure JSON output is valid (current implementation writes `[` then items then seeks back — this is fragile; use `json.dump(list)` instead)
+
+### Exit Code Strategy
+
+Current: `exit(0)` for success, `exit(1)` for signal handler.
+
+Proposed:
+- `0` — success
+- `1` — runtime error (network failure, API error)
+- `2` — usage error (invalid arguments)
+
+### Verbose/Debug Behavior
+
+Current: `--log` flag with choices `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`.
+
+This is adequate. Improvement: add `-v` as shorthand for `--log DEBUG`.
+
+---
+
+## 10. SQLite Cache Optimization Plan
+
+### Current Schema Assessment
+
+The schema is simple and functional:
+```sql
+CREATE TABLE INDEX_PAKET (
+    ROW_ID varchar(100) unique primary key,
+    ID_PAKET VARCHAR(50),
+    JENIS_PAKET VARCHAR(32),
+    KATEGORI_TAHUN_ANGGARAN varchar(100),
+    STATUS int default 0,
+    DETAIL text
+);
+```
+
+This is adequate for the use case. No changes needed to the schema itself.
+
+### Cache Key Strategy
+
+`ROW_ID = "{tender|nontender}-{id_paket}"` is a good composite key. No changes needed.
+
+### Suggested Indexes
+
+Current indexes are appropriate:
+- `KATEGORI_TAHUN_ANGGARAN` — used for year filtering
+- `ID_PAKET` — used for lookups
+- `JENIS_PAKET` — used for type filtering
+- `STATUS` — used for pending/completed queries
+
+No additional indexes needed.
+
+### TTL/Expiration Strategy
+
+There is no TTL. The cache is a download-progress database, not a response cache. TTL is not applicable — the `--resume` feature relies on persistence.
+
+No TTL should be added.
+
+### Cache Invalidation Strategy
+
+Current: `DROP TABLE IF EXISTS` on non-resume runs. This is correct — the cache is disposable per-download.
+
+No changes needed.
+
+### Connection Management
+
+Current: `sqlite3.connect()` in `IndexDownloader.__init__`, closed in `__del__`.
+
+Proposed: Context manager pattern in `CacheStore` (see Task 5).
+
+### Migration Strategy
+
+No schema migration needed. The schema is stable and simple.
+
+For `--resume` compatibility: the `CacheStore.create_schema()` method must produce the exact same table and index names. Existing `.idx` files must continue to work.
+
+### Testing with Temporary SQLite Files
+
+Use `tempfile.NamedTemporaryFile(suffix='.idx')` in tests:
+```python
+with tempfile.NamedTemporaryFile(suffix='.idx', delete=False) as f:
+    db_path = Path(f.name)
+    with CacheStore(db_path) as store:
+        store.create_schema()
+        # ... test operations
+```
+
+---
+
+## 11. Testing Strategy
+
+### Tests Needed Before Refactor (Phase 0)
+
+| Test | Type | Purpose |
+|------|------|---------|
+| Mocked `Lpse.get_paket()` success | Unit | Verify JSON parsing, `data_only` flag |
+| Mocked `Lpse.get_paket()` error | Unit | Verify exception on 400+ and error text |
+| Mocked `Lpse.get_auth_token()` | Unit | Verify cookie and JS parsing paths |
+| Mocked parser `parse_detil()` | Unit | Verify HTML parsing with fixture files |
+| `DownloaderContext` argument parsing | Unit | Verify all argument combinations |
+| `LpseHost` parsing | Unit | Verify URL/filename extraction |
+| `parse_tahun_anggaran()` | Unit | Verify single, range, comma, "all", invalid |
+| `Exporter.to_csv()` with temp DB | Unit | Verify CSV output format |
+| `Exporter.to_json()` with temp DB | Unit | Verify JSON output format |
+| `CacheStore` CRUD operations | Unit | Verify insert, update, query with temp DB |
+
+### Tests Needed After Refactor
+
+| Test | Type | Purpose |
+|------|------|---------|
+| `CacheStore` context manager cleanup | Unit | Verify connection closed on normal and exception paths |
+| CLI subcommand routing | Unit | Verify `download`, `daftarlpse`, `daftarhost` dispatch |
+| Backward-compatible argument parsing | Unit | Verify old invocation style still works |
+| `--resume` with existing `.idx` file | Integration | Verify schema compatibility |
+| Full pipeline with mocked HTTP | Integration | Verify IndexDownloader → DetailDownloader → Exporter |
+
+### Test Infrastructure
+
+- `conftest.py` with shared fixtures: mock `Lpse` instance, temporary SQLite path, fixture HTML/JSON loading helpers
+- Mark integration tests with `@pytest.mark.integration`
+- Default `pytest` runs unit tests only; `pytest -m integration` runs live tests
+
+---
+
+## 12. Risk Register
+
+| Risk | Area | Severity | Mitigation |
+|---|---|---|---|
+| Breaking `--resume` for existing `.idx` files | SQLite Cache | High | Preserve exact schema in `CacheStore`; test with existing `.idx` files before and after |
+| Breaking `from pyproc.cli import *` in tests | Code Structure | Medium | Add re-exports in `cli.py` after splitting modules |
+| Breaking external code that imports from `pyproc.cli` | Code Structure | Medium | Keep re-exports; document any moved classes |
+| `utils.download_host()` `logging` parameter removal | API Wrapper | Medium | Document breaking change; update all callers |
+| Argparse subparser backward compatibility | CLI Wrapper | Medium | Default to `download` when no subcommand given; test old invocation patterns |
+| Thread safety if workers re-enabled | Reliability | Medium | Keep `workers=1` by default; add proper locking if re-enabling |
+| Test fixture staleness | Testing | Low | Document refresh procedure; fixtures are for unit tests only |
+| Type hint syntax errors on Python 3.9 | Code Structure | Low | Use `from __future__ import annotations`; test on 3.9 |
+
+---
+
+## 13. Recommended Execution Order
+
+1. **Task 1** (Capture fixtures) — no code changes, enables all subsequent testing
+2. **Task 2** (Mocked API tests) — safety net for API layer
+3. **Task 3** (Mocked CLI tests) — safety net for CLI layer
+4. **Task 4** (Fix bugs) — clean baseline before refactoring
+5. **Task 6** (Move SSL config) — small, safe boundary cleanup
+6. **Task 7** (Context managers) — small, safe reliability improvement
+7. **Task 5** (Extract cache) — biggest structural improvement; depends on Task 3 for safety
+8. **Task 11** (Type hints) — additive, no risk, improves subsequent work
+9. **Task 10** (Clean up utils.py) — small boundary cleanup
+10. **Task 9** (Fix workers argument) — small CLI cleanup
+11. **Task 8** (Subparsers) — CLI improvement; depends on Tasks 3, 5 for safety
+12. **Task 12** (pyproject.toml) — metadata cleanup, no code risk
+
+---
+
+## 14. Out of Scope
+
+The following should NOT be done unless explicitly requested:
+
+- Replacing SQLite with PostgreSQL, Redis, or any other database
+- Adding a web framework or REST API layer
+- Full rewrite of `lpse.py` or `cli.py`
+- Async rewrite (the project uses synchronous `requests` and threading; async would be a major rewrite)
+- ORM adoption (SQLAlchemy, etc.) — raw sqlite3 is appropriate for this use case
+- Breaking CLI command redesign (preserving existing invocation patterns)
+- Breaking public Python API redesign (preserving `Lpse` class interface)
+- Adding configuration file support (e.g., `~/.pyproc/config.toml`)
+- Adding authentication beyond the current CSRF token approach
+- Supporting multiple SPSE servers (the base URL is hardcoded to `spse.inaproc.id`)
+- Adding pagination auto-detection or streaming
+- Containerization (Docker)
+- Adding a plugin system or extension mechanism

--- a/pyproc/cache.py
+++ b/pyproc/cache.py
@@ -1,0 +1,145 @@
+"""SQLite cache store for procurement index and detail data."""
+import json
+import logging
+import sqlite3
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS INDEX_PAKET (
+    ROW_ID varchar(100) unique primary key,
+    ID_PAKET VARCHAR(50),
+    JENIS_PAKET VARCHAR(32),
+    KATEGORI_TAHUN_ANGGARAN varchar(100),
+    STATUS int default 0,
+    DETAIL text
+);
+"""
+
+INDEXES_SQL = [
+    "CREATE INDEX IF NOT EXISTS INDEX_PAKET_KATEGORI_TAHUN_ANGGARAN_IDX ON INDEX_PAKET(KATEGORI_TAHUN_ANGGARAN);",
+    "CREATE INDEX IF NOT EXISTS INDEX_PAKET_ID_PAKET_IDX ON INDEX_PAKET(ID_PAKET);",
+    "CREATE INDEX IF NOT EXISTS INDEX_PAKET_JENIS_PAKET ON INDEX_PAKET(JENIS_PAKET);",
+    "CREATE INDEX IF NOT EXISTS INDEX_PAKET_STATUS_IDX ON INDEX_PAKET(STATUS);",
+]
+
+DROP_SQL = "DROP TABLE IF EXISTS INDEX_PAKET;"
+
+
+class CacheStore:
+    """Manages a SQLite database for procurement index and detail caching.
+
+    Usage::
+
+        with CacheStore(db_path) as store:
+            store.create_schema()
+            store.insert_rows(rows)
+            for item in store.get_pending():
+                ...
+    """
+
+    def __init__(self, db_path: Path):
+        self.db_path = db_path
+        self.db = None
+
+    def __enter__(self):
+        self.db = sqlite3.connect(str(self.db_path), check_same_thread=False)
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+        return False
+
+    def close(self):
+        if self.db:
+            self.db.close()
+            self.db = None
+
+    def create_schema(self):
+        """Create the INDEX_PAKET table and indexes if they don't exist."""
+        self.db.executescript(SCHEMA_SQL)
+        for idx_sql in INDEXES_SQL:
+            self.db.execute(idx_sql)
+        self.db.commit()
+
+    def drop_schema(self):
+        """Drop the INDEX_PAKET table if it exists."""
+        self.db.execute(DROP_SQL)
+        self.db.commit()
+
+    def reset(self):
+        """Drop and recreate the schema (full reset)."""
+        self.drop_schema()
+        self.create_schema()
+
+    def has_rows(self):
+        """Return True if the INDEX_PAKET table has any rows."""
+        try:
+            total = self.db.execute("SELECT COUNT(1) FROM INDEX_PAKET").fetchone()[0]
+            return total > 0
+        except sqlite3.OperationalError:
+            return False
+
+    def insert_rows(self, rows):
+        """Insert multiple rows using INSERT OR IGNORE for deduplication.
+
+        Args:
+            rows: iterable of tuples matching INDEX_PAKET columns
+                  (ROW_ID, ID_PAKET, JENIS_PAKET, KATEGORI_TAHUN_ANGGARAN, STATUS, DETAIL)
+        """
+        self.db.executemany(
+            "INSERT OR IGNORE INTO INDEX_PAKET VALUES(?, ?, ?, ?, ?, ?)",
+            rows
+        )
+        self.db.commit()
+
+    def get_pending(self):
+        """Yield rows where STATUS=0 (pending detail download).
+
+        Each row is returned as a dict with lowercase column names.
+        """
+        cursor = self.db.execute("SELECT * FROM INDEX_PAKET WHERE STATUS = 0")
+        for row in cursor.fetchall():
+            yield self._row_to_dict(cursor, row)
+
+    def get_completed(self):
+        """Yield rows where STATUS=1 (detail downloaded).
+
+        Each row is returned as a dict with lowercase column names.
+        """
+        cursor = self.db.execute("SELECT * FROM INDEX_PAKET WHERE STATUS = 1")
+        for row in cursor.fetchall():
+            yield self._row_to_dict(cursor, row)
+
+    def update_detail(self, row_id, detail_json):
+        """Update a row's DETAIL and set STATUS=1.
+
+        Args:
+            row_id: the ROW_ID primary key
+            detail_json: JSON string of the detail data
+        """
+        self.db.execute(
+            "UPDATE INDEX_PAKET SET DETAIL = ?, STATUS = 1 WHERE ROW_ID = ?",
+            (detail_json, row_id)
+        )
+        self.db.commit()
+
+    def count_by_status(self):
+        """Return a dict mapping status code to count.
+
+        Returns:
+            dict: {0: pending_count, 1: completed_count}
+        """
+        rows = self.db.execute(
+            "SELECT STATUS, COUNT(1) FROM INDEX_PAKET GROUP BY STATUS"
+        ).fetchall()
+        return dict(rows)
+
+    @staticmethod
+    def _row_to_dict(cursor, row):
+        """Convert a sqlite3 row to a dict with lowercase column names."""
+        d = {}
+        for idx, col in enumerate(cursor.description):
+            d[col[0].lower()] = row[idx]
+        return d

--- a/pyproc/cli.py
+++ b/pyproc/cli.py
@@ -3,20 +3,17 @@ import csv
 import re
 import logging
 import signal
-import sqlite3
+import sys
 import threading
 import requests
 import pyproc
 import json
 from time import sleep
 from .exceptions import DownloaderContextException
+from .cache import CacheStore
 from . import text
 from datetime import datetime
 from pathlib import Path
-from urllib3.exceptions import InsecureRequestWarning
-from urllib3 import disable_warnings
-
-disable_warnings(InsecureRequestWarning)
 
 
 def set_up_log(level):
@@ -200,16 +197,16 @@ class LpseIndex:
     def parse_detail(detail):
         try:
             return json.loads(detail)
-        except TypeError:
-            return {}
+        except (TypeError, json.JSONDecodeError, ValueError):
+            return None
 
     def __str__(self):
         return str(self.__dict__)
 
 
 class IndexDownloader(object):
-    __tahun_anggaran_pattern = re.compile('(\d+)')
-    db = None
+    __tahun_anggaran_pattern = re.compile(r'(\d+)')
+    store = None
     db_status_for_resume = False
     db_file = None
     lpse = None
@@ -218,75 +215,36 @@ class IndexDownloader(object):
         self.ctx = ctx
         self.lpse_host = lpse_host
         self.lpse = pyproc.Lpse(lpse_host.url, timeout=ctx.timeout)
-        self.db = self.get_index_db(self.lpse_host.filename)
+        self.store = self._init_cache(self.lpse_host.filename)
+        # Keep self.db as alias for backward compatibility
+        self.db = self.store.db
 
         logging.info("{} - Mulai pengunduhan data {} tahun {}".format(
             lpse_host.url, "Pengadaan Langsung" if self.ctx.non_tender else "Tender",
             ', '.join(map(str, self.ctx.tahun_anggaran)) if self.ctx.tahun_anggaran[0] is not None else 'ALL'
         ))
 
-    def __check_index_db(self, db):
-        status = False
-        try:
-            total = db.execute("SELECT COUNT(1) FROM INDEX_PAKET").fetchone()[0]
-            logging.info("{} - total previous index {}".format(self.lpse_host.url, total))
-            if total > 0:
-                status = True
-        except Exception as e:
-            logging.error("{} - check index db gagal, error: {}".format(self.lpse_host.url, e))
-            status = False
-
-        logging.info("{} - status previous index db {}".format(self.lpse_host.url, status))
-        self.db_status_for_resume = status
-        return status
-
-    def get_index_db(self, filename):
+    def _init_cache(self, filename):
         """
-        Generate index database and table
-        table columns:
-            - data_id, concat(jenis, idpaket).
-            - nama_instansi
-            - jenis_paket
-            - kategori_tahun_anggaran
-            - status (0 belum download, 1 oke)
-        :param filename: Database Filename
-        :return: SQLite database object
+        Initialize the cache store for this downloader.
+
+        :param filename: Path object for the host filename
+        :return: CacheStore instance (already entered as context manager)
         """
         db_filename = filename.name + ".idx"
         self.db_file = Path.cwd() / db_filename
-        db = sqlite3.connect(str(self.db_file), check_same_thread=False)
 
-        if self.ctx.resume and self.__check_index_db(db):
+        store = CacheStore(self.db_file)
+        store.__enter__()
+
+        if self.ctx.resume and store.has_rows():
             logging.info("{} - skip db init, melanjutkan proses".format(self.lpse_host.url))
-            return db
+            self.db_status_for_resume = True
+            return store
 
         logging.debug("Generate index database: {}".format(self.db_file.name))
-        logging.debug("Create index table")
-
-        try:
-            db.execute("DROP TABLE IF EXISTS INDEX_PAKET")
-            db.execute("""CREATE TABLE INDEX_PAKET
-            (
-            ROW_ID varchar(100) unique primary key,
-            ID_PAKET VARCHAR(50),
-            JENIS_PAKET VARCHAR(32),
-            KATEGORI_TAHUN_ANGGARAN varchar (100),
-            STATUS int default 0,
-            DETAIL text
-            );""")
-            db.execute("CREATE INDEX INDEX_PAKET_KATEGORI_TAHUN_ANGGARAN_IDX ON INDEX_PAKET(KATEGORI_TAHUN_ANGGARAN);")
-            db.execute("CREATE INDEX INDEX_PAKET_ID_PAKET_IDX ON INDEX_PAKET(ID_PAKET);")
-            db.execute("CREATE INDEX INDEX_PAKET_JENIS_PAKET ON INDEX_PAKET(JENIS_PAKET);")
-            db.execute("CREATE INDEX INDEX_PAKET_STATUS_IDX ON INDEX_PAKET(STATUS);")
-        except sqlite3.OperationalError as e:
-            if 'INDEX_PAKET already exists' in str(e):
-                pass
-            else:
-                raise e
-
-        db.commit()
-
-        return db
+        store.reset()
+        return store
 
     def get_jenis_paket(self):
         """
@@ -336,9 +294,7 @@ class IndexDownloader(object):
                 if not data:
                     break
 
-                self.db.executemany("INSERT OR IGNORE INTO INDEX_PAKET VALUES(?, ?, ?, ?, ?, ?)",
-                                    self.convert_index_for_db(data))
-                self.db.commit()
+                self.store.insert_rows(self.convert_index_for_db(data))
 
                 # update data count
                 data_count += len(data)
@@ -378,13 +334,8 @@ class IndexDownloader(object):
 
     def get_index(self):
         logging.debug("[SQL] get index from database")
-        result = self.db.execute("SELECT * FROM INDEX_PAKET WHERE STATUS = 0")
-
-        for row in result.fetchall():
-            row = self.index_factory(result, row)
-
-            logging.debug("row data {}".format(row))
-            yield row
+        for row_dict in self.store.get_pending():
+            yield LpseIndex(row_dict)
 
     def resume(self):
         """
@@ -398,9 +349,8 @@ class IndexDownloader(object):
         Make sure everything is closed when object is garbage collected
         :return:
         """
-        if self.db:
-            self.db.close()
-            del self.db
+        if self.store:
+            self.store.close()
 
         if self.lpse is not None:
             del self.lpse
@@ -415,9 +365,8 @@ class DetailDownloader(object):
         logging.info("{} - Mulai pengunduhan detail data".format(self.index_downloader.lpse_host.url))
 
     def __pre_process_index_db(self):
-        total = self.index_downloader.db.execute(
-            """SELECT COUNT(1) FROM INDEX_PAKET WHERE STATUS = 0"""
-        ).fetchone()[0]
+        counts = self.index_downloader.store.count_by_status()
+        total = counts.get(0, 0)
         deleted = 0
 
         return total, deleted
@@ -448,11 +397,10 @@ class DetailDownloader(object):
     def update_detail(self, lpse_index):
         with self.lock:
             logging.debug("[DETAIL DOWNLOADER] update detail data {}".format(lpse_index))
-            self.index_downloader.db.execute(
-                "UPDATE INDEX_PAKET SET DETAIL = ?, STATUS = 1 WHERE ROW_ID = ?",
-                (json.dumps(lpse_index.detail.todict()), lpse_index.row_id)
+            self.index_downloader.store.update_detail(
+                lpse_index.row_id,
+                json.dumps(lpse_index.detail.todict())
             )
-            self.index_downloader.db.commit()
 
     def start(self):
         total, deleted = self.__pre_process_index_db()
@@ -518,10 +466,14 @@ class Exporter:
         :return: generator result row
         """
         logging.info("{} - Export Data".format(self.index_downloader.lpse_host.url))
-        result = self.index_downloader.db.execute("SELECT * from INDEX_PAKET WHERE STATUS = 1")
-        for data in result.fetchall():
-            data = self.index_downloader.index_factory(result, data)
-            yield data.detail
+        for row_dict in self.index_downloader.store.get_completed():
+            detail = row_dict.get('detail')
+            if isinstance(detail, str):
+                try:
+                    detail = json.loads(detail)
+                except (json.JSONDecodeError, TypeError):
+                    continue
+            yield detail
 
     def get_file_obj(self, ext):
         """
@@ -612,8 +564,7 @@ class QualityAssurance:
         self.index_downloader = index_downloader
 
     def check(self):
-        all_data = self.index_downloader.db.execute("SELECT STATUS, COUNT(1) FROM INDEX_PAKET GROUP BY STATUS")
-        result = dict(all_data.fetchall())
+        result = self.index_downloader.store.count_by_status()
         success = result.get(1, 0)
         fail = result.get(0, 0)
         total = sum(result.values())
@@ -689,7 +640,7 @@ class Downloader(object):
                             help=text.HELP_KATEGORI, default=None)
         parser.add_argument('--nama-penyedia', type=str, default=None, help=text.HELP_PENYEDIA)
         parser.add_argument('-c', '--chunk-size', type=int, default=100, help=text.HELP_CHUNK_SIZE)
-        parser.add_argument('-w', '--workers', type=int, default=8, help=text.HELP_WORKERS)
+        parser.add_argument('-w', '--workers', type=int, default=8, help=argparse.SUPPRESS)
         parser.add_argument('-x', '--timeout', type=int, default=30, help=text.HELP_TIMEOUT)
         parser.add_argument('-n', '--non-tender', action='store_true', help=text.HELP_NONTENDER)
         parser.add_argument('-d', '--index-download-delay', type=int, default=1, help=text.HELP_INDEX_DOWNLOAD_DELAY)
@@ -755,7 +706,7 @@ class Downloader(object):
 
             if not index_downloader.ctx.keep_index and fail == 0:
                 logging.info("{} - membersihkan direktori".format(lpse_host.url))
-                index_downloader.db.close()
+                index_downloader.store.close()
                 try:
                     index_downloader.db_file.unlink()
                 except FileNotFoundError:
@@ -767,27 +718,35 @@ class Downloader(object):
 
 
 def main():
-    import sys
-
     IWillFindYouAndIWillKillYou()
 
     print(text.INFO)
 
-    # Subcommand: daftarlpse
-    if len(sys.argv) > 1 and sys.argv[1] == 'daftarlpse':
-        set_up_log('INFO')
-        pyproc.utils.download_host(logging)
-        exit(0)
+    # Detect subcommands by checking if first arg is a known subcommand
+    # For backward compatibility, treat non-subcommand args as download args
+    known_subcommands = {'daftarlpse', 'daftarhost', 'download'}
 
-    # Subcommand: daftarhost
-    if len(sys.argv) > 1 and sys.argv[1] == 'daftarhost':
-        set_up_log('INFO')
-        directory = sys.argv[2] if len(sys.argv) > 2 else '.'
-        pyproc.utils.download_host_json(logging, directory=directory)
-        exit(0)
+    if len(sys.argv) > 1 and sys.argv[1] in known_subcommands:
+        subcommand = sys.argv[1]
+        remaining_args = sys.argv[2:]
+    else:
+        subcommand = 'download'
+        remaining_args = sys.argv[1:]
 
+    if subcommand == 'daftarlpse':
+        set_up_log('INFO')
+        pyproc.utils.download_host()
+        sys.exit(0)
+
+    if subcommand == 'daftarhost':
+        set_up_log('INFO')
+        directory = remaining_args[0] if remaining_args else '.'
+        pyproc.utils.download_host_json(directory=directory)
+        sys.exit(0)
+
+    # Default: download
     downloader = Downloader()
-    downloader.get_ctx(sys.argv[1:])
+    downloader.get_ctx(remaining_args)
 
     try:
         status, current, new = check_new_version()

--- a/pyproc/lpse.py
+++ b/pyproc/lpse.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import time
 import bs4
 import requests
@@ -9,7 +11,10 @@ from bs4 import BeautifulSoup as Bs, NavigableString
 from .exceptions import LpseVersionException, LpseServerExceptions, LpseHostExceptions
 from enum import Enum
 from abc import abstractmethod
+from typing import Optional, Any
 from urllib.parse import urlparse
+from urllib3.exceptions import InsecureRequestWarning
+from urllib3 import disable_warnings
 
 
 class By(Enum):
@@ -33,21 +38,30 @@ class JenisPengadaan(Enum):
 
 class Lpse(object):
 
-    def __init__(self, instansi, timeout=10):
+    def __init__(self, instansi: str, timeout: int = 10, verify: bool = False):
         self.session = requests.session()
-        self.session.verify = False
+        self.session.verify = verify
+        if not verify:
+            disable_warnings(InsecureRequestWarning)
         self.session.headers = {
             'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) '
                           'AppleWebKit/537.36 (KHTML, like Gecko) '
                           'Chrome/102.0.5005.61 Safari/537.36'
         }
         self.timeout = timeout
-        self.auth_token = None
+        self.auth_token: Optional[str] = None
         self.url = f"https://spse.inaproc.id/{instansi}"
+
+    def __enter__(self) -> Lpse:
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> bool:
+        self.session.close()
+        return False
 
 
     @staticmethod
-    def check_error(resp):
+    def check_error(resp: requests.Response) -> None:
         error_message = None
         content = resp.text
 
@@ -69,7 +83,7 @@ class Lpse(object):
             )
             raise LpseServerExceptions(error_message)
 
-    def get_auth_token(self, from_cookies=True):
+    def get_auth_token(self, from_cookies: bool = True) -> Optional[str]:
         """
         Melakukan pengambilan auth token
         :return: token (str)
@@ -89,9 +103,11 @@ class Lpse(object):
                           (LpseServerExceptions, requests.exceptions.RequestException,
                            requests.exceptions.ConnectionError),
                           jitter=None, max_tries=3)
-    def get_paket(self, jenis_paket, start=0, length=0, data_only=False,
-                  kategori=None, search_keyword=None, nama_penyedia=None,
-                  order=By.KODE, tahun=None, ascending=False, instansi_id=None):
+    def get_paket(self, jenis_paket: str, start: int = 0, length: int = 0,
+                  data_only: bool = False, kategori: Optional[JenisPengadaan] = None,
+                  search_keyword: Optional[str] = None, nama_penyedia: Optional[str] = None,
+                  order: By = By.KODE, tahun: Optional[int] = None, ascending: bool = False,
+                  instansi_id: Optional[str] = None) -> dict | list:
         """
         Melakukan pencarian paket pengadaan
         :param jenis_paket: Paket Pengadaan Lelang (lelang) atau Penunjukkan Langsung (pl)
@@ -218,7 +234,7 @@ class Lpse(object):
         return self.get_paket('pl', start, length, data_only, kategori, search_keyword, None, order, tahun,
                               ascending, instansi_id)
 
-    def detil_paket_tender(self, id_paket):
+    def detil_paket_tender(self, id_paket: int | str) -> LpseDetil:
         """
         Mengambil detil pengadaan
         :param id_paket:
@@ -240,18 +256,18 @@ class Lpse(object):
 
 
 class BaseLpseDetil(object):
-    def __init__(self, lpse, id_paket):
+    def __init__(self, lpse: Lpse, id_paket: int | str):
         self._lpse = lpse
         self.id_paket = id_paket
-        self.pengumuman = None
-        self.peserta = None
-        self.hasil = None
-        self.pemenang = None
-        self.pemenang_berkontrak = None
-        self.jadwal = None
+        self.pengumuman: Optional[dict] = None
+        self.peserta: Optional[list] = None
+        self.hasil: Optional[list] = None
+        self.pemenang: Optional[list] = None
+        self.pemenang_berkontrak: Optional[list] = None
+        self.jadwal: Optional[list] = None
 
-    def get_all_detil(self):
-        info = {
+    def get_all_detil(self) -> dict:
+        info: dict = {
             'error': False,
             'error_message': []
         }
@@ -266,10 +282,10 @@ class BaseLpseDetil(object):
                 )
         return info
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self.todict())
 
-    def todict(self):
+    def todict(self) -> dict:
         data = self.__dict__.copy()
         data.pop('_lpse')
         return data

--- a/pyproc/utils.py
+++ b/pyproc/utils.py
@@ -1,17 +1,20 @@
 import csv
 import json
+import logging
 import os
 import re
 import requests
 from bs4 import BeautifulSoup
 from urllib.parse import urlparse
 
+logger = logging.getLogger(__name__)
+
 TOKEN_FORMAT = re.compile(r"d\.authenticityToken[\s+]=[\s+]['\"]([0-9a-zA-Z]+)['\"];", re.DOTALL)
 
 GIST_HOST_URL = 'https://gist.githubusercontent.com/wakataw/54d206da0e6238253d364b04bb149cdd/raw'
 
 
-def parse_token(page):
+def parse_token(page: str):
     token = TOKEN_FORMAT.findall(page)
 
     if token:
@@ -22,12 +25,14 @@ def parse_token(page):
 
 def get_all_host():
     resp = requests.get('https://satudata.inaproc.id/service/daftarLPSE', timeout=10)
-    data = json.loads(resp.content)
+    resp.raise_for_status()
+    data = resp.json()
 
     return data
 
 
-def download_host(logging, name='daftarlpse.csv'):
+def download_host(name: str = 'daftarlpse.csv'):
+    """Download host list from inaproc API and export to CSV."""
     data = get_all_host()
     hosts = dict()
     invalid_host = 0
@@ -47,25 +52,24 @@ def download_host(logging, name='daftarlpse.csv'):
         hosts[url] = str(item['repo_id']) + '-' + \
             ' '.join([i for i in re.sub(r'[^a-zA-Z\d\s]', ' ', item['repo_nama']).split() if i.strip() != ''])
 
-    logging.info(
+    logger.info(
         "{} alamat LPSE ditemukan. {} alamat valid, {} alamat tidak valid, {} alamat terduplikasi.".format(
             len(data), len(hosts), invalid_host, len(data) - len(hosts) - invalid_host
         )
     )
-    logging.debug(hosts)
+    logger.debug(hosts)
 
     with open(name, 'w', newline='', encoding='utf-8') as f:
         writer = csv.writer(f, delimiter=';')
         for k, v in hosts.items():
             writer.writerow([k, v])
 
-    logging.info("Export daftar lpse ke {}".format(name))
+    logger.info("Export daftar lpse ke {}".format(name))
 
 
-def download_host_json(logging, name='host.json', directory='.'):
+def download_host_json(name: str = 'host.json', directory: str = '.'):
     """
     Download host.json dari GitHub Gist
-    :param logging: logging module
     :param name: nama file output
     :param directory: direktori output
     :return: data host dalam format list
@@ -80,11 +84,11 @@ def download_host_json(logging, name='host.json', directory='.'):
     with open(filepath, 'w', encoding='utf-8') as f:
         json.dump(data, f, indent=2, ensure_ascii=False)
 
-    logging.info("Export host.json ke {}".format(filepath))
+    logger.info("Export host.json ke {}".format(filepath))
 
     return data
 
 
-def parse_version(version):
+def parse_version(version: str):
     version = tuple(map(int, re.findall(r'(?P<major>\d+).(?P<minor>\d+)u(?P<patch>\d{8})', version)[0]))
     return version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,10 @@ classifiers = [
     'Natural Language :: English',
     'Natural Language :: Indonesian',
     'Operating System :: OS Independent',
-    'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
     'License :: OSI Approved :: MIT License'
 ]
 license = "MIT"
@@ -31,6 +34,9 @@ dependencies = [
     "html5lib",
     "backoff"
 ]
+
+[project.optional-dependencies]
+test = ["pytest"]
 
 [project.urls]
 Homepage = "https://github.com/wakataw/pyproc"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-backoff
-beautifulsoup4
-html5lib
-requests
-

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -1,0 +1,43 @@
+# Test Fixtures
+
+This directory contains captured SPSE HTML/JSON responses used by mocked unit tests.
+
+## Files
+
+| File | Source | Description |
+|------|--------|-------------|
+| `lelang_page.html` | `GET /{instansi}/lelang` | Main lelang page with auth token in JavaScript |
+| `dt_lelang.json` | `POST /dt/lelang` | DataTables JSON response (full) |
+| `dt_lelang_data_only.json` | `POST /dt/lelang` | DataTables JSON response (data_only=True) |
+| `pengumuman_lelang.html` | `GET /lelang/{id}/pengumumanlelang` | Tender announcement detail page |
+| `peserta.html` | `GET /lelang/{id}/peserta` | Participant list page |
+| `hasil_evaluasi.html` | `GET /evaluasi/{id}/hasil` | Evaluation results page |
+| `pemenang.html` | `GET /evaluasi/{id}/pemenang` | Winner page |
+| `jadwal.html` | `GET /lelang/{id}/jadwal` | Schedule page |
+| `error_page.html` | Synthetic | SPSE error page with error code |
+| `not_found_page.html` | Synthetic | SPSE 404 page |
+
+## Refreshing Fixtures
+
+To refresh fixtures with real data:
+
+```python
+from pyproc import Lpse
+
+lpse = Lpse("kemenkeu", timeout=30)
+
+# Auth page
+resp = lpse.session.get(lpse.url + '/lelang')
+with open('lelang_page.html', 'w') as f:
+    f.write(resp.text)
+
+# DataTables
+resp = lpse.session.post(lpse.url + '/dt/lelang', data={...})
+with open('dt_lelang.json', 'w') as f:
+    f.write(resp.text)
+
+# Detail pages
+resp = lpse.session.get(lpse.url + '/lelang/10080116000/pengumumanlelang')
+with open('pengumuman_lelang.html', 'w') as f:
+    f.write(resp.text)
+```

--- a/tests/fixtures/dt_lelang.json
+++ b/tests/fixtures/dt_lelang.json
@@ -1,0 +1,9 @@
+{
+    "draw": 1,
+    "recordsTotal": 2,
+    "recordsFiltered": 2,
+    "data": [
+        [10080116000, "Paket Lelang Test 1", "KEMENTERIAN KEUANGAN", "Tender Sudah Selesai", "", "2025", "", "", "Pengadaan Barang - 2025"],
+        [10080117000, "Paket Lelang Test 2", "KEMENTERIAN KEUANGAN", "Tender Sedang Berlangsung", "", "2025", "", "", "Jasa Konsultansi - 2025"]
+    ]
+}

--- a/tests/fixtures/dt_lelang_data_only.json
+++ b/tests/fixtures/dt_lelang_data_only.json
@@ -1,0 +1,4 @@
+[
+    [10080116000, "Paket Lelang Test 1", "KEMENTERIAN KEUANGAN", "Tender Sudah Selesai", "", "2025", "", "", "Pengadaan Barang - 2025"],
+    [10080117000, "Paket Lelang Test 2", "KEMENTERIAN KEUANGAN", "Tender Sedang Berlangsung", "", "2025", "", "", "Jasa Konsultansi - 2025"]
+]

--- a/tests/fixtures/error_page.html
+++ b/tests/fixtures/error_page.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head><title>Error</title></head>
+<body>
+<div class="content">
+    <h1>Maaf, terjadi error pada aplikasi SPSE.</h1>
+    <p>Kode Error: ERR500TEST</p>
+</div>
+</body>
+</html>

--- a/tests/fixtures/hasil_evaluasi.html
+++ b/tests/fixtures/hasil_evaluasi.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head><title>Hasil Evaluasi</title></head>
+<body>
+<div class="content">
+    <table class="table">
+        <tr>
+            <th>No</th>
+            <th>Nama Peserta</th>
+            <th>NPWP</th>
+            <th>Evaluasi Administrasi</th>
+            <th>Evaluasi Teknis</th>
+            <th>Skor Teknis</th>
+            <th>Penawaran</th>
+            <th>Penawaran Terkoreksi</th>
+            <th>Hasil Negosiasi</th>
+            <th>Skor Harga</th>
+            <th>Skor Akhir</th>
+            <th>Pemenang</th>
+        </tr>
+        <tr>
+            <td>1</td>
+            <td>PT. Test Satu</td>
+            <td>01.234.567.8-012.000</td>
+            <td><i class="fa fa-check"></i></td>
+            <td><i class="fa fa-check"></i></td>
+            <td>85.00</td>
+            <td>Rp 900.000.000,00</td>
+            <td>Rp 900.000.000,00</td>
+            <td>Rp 900.000.000,00</td>
+            <td>95.00</td>
+            <td>90.00</td>
+            <td><img src="star.gif" /></td>
+        </tr>
+        <tr>
+            <td>2</td>
+            <td>CV. Test Dua</td>
+            <td>02.345.678.9-023.000</td>
+            <td><i class="fa fa-check"></i></td>
+            <td><i class="fa fa-close"></i></td>
+            <td>0.00</td>
+            <td>Rp 920.000.000,00</td>
+            <td>Rp 920.000.000,00</td>
+            <td>Rp 920.000.000,00</td>
+            <td>0.00</td>
+            <td>0.00</td>
+            <td><i class="fa fa-minus"></i></td>
+        </tr>
+    </table>
+</div>
+</body>
+</html>

--- a/tests/fixtures/jadwal.html
+++ b/tests/fixtures/jadwal.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head><title>Jadwal</title></head>
+<body>
+<table class="table">
+    <tr>
+        <th>No</th>
+        <th>Tahap</th>
+        <th>Mulai</th>
+        <th>Sampai</th>
+        <th>Perubahan</th>
+    </tr>
+    <tr>
+        <td>1</td>
+        <td>Pengadaan Langsung / Pemilihan Langsung</td>
+        <td>15 Januari 2025 08:00</td>
+        <td>20 Januari 2025 17:00</td>
+        <td>-</td>
+    </tr>
+    <tr>
+        <td>2</td>
+        <td>Evaluasi</td>
+        <td>21 Januari 2025 08:00</td>
+        <td>25 Januari 2025 17:00</td>
+        <td>-</td>
+    </tr>
+</table>
+</body>
+</html>

--- a/tests/fixtures/lelang_page.html
+++ b/tests/fixtures/lelang_page.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head><title>SPSE - Lelang</title></head>
+<body>
+<script>
+d.authenticityToken = 'TESTTOKENABC123XYZ';
+</script>
+<div class="content">
+    <h1>Daftar Paket Lelang</h1>
+    <table class="table table-bordered">
+        <thead><tr><th>Kode</th><th>Nama</th></tr></thead>
+        <tbody></tbody>
+    </table>
+</div>
+</body>
+</html>

--- a/tests/fixtures/not_found_page.html
+++ b/tests/fixtures/not_found_page.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head><title>404</title></head>
+<body>
+<div class="content">
+    <h1>Halaman yang dituju tidak ditemukan</h1>
+</div>
+</body>
+</html>

--- a/tests/fixtures/pemenang.html
+++ b/tests/fixtures/pemenang.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head><title>Pemenang</title></head>
+<body>
+<div class="content">
+    <table class="table">
+        <tbody>
+            <tr>
+                <td colspan="3">
+                    <table class="table table-bordered">
+                        <tr>
+                            <th>No</th>
+                            <th>Nama Pemenang</th>
+                            <th>Alamat</th>
+                            <th>NPWP</th>
+                            <th>Harga Penawaran</th>
+                            <th>Harga Terkoreksi</th>
+                            <th>Hasil Negosiasi</th>
+                        </tr>
+                        <tr>
+                            <td>1</td>
+                            <td>PT. Test Satu</td>
+                            <td>Jl. Test No. 1, Jakarta</td>
+                            <td>01.234.567.8-012.000</td>
+                            <td>Rp 900.000.000,00</td>
+                            <td>Rp 900.000.000,00</td>
+                            <td>Rp 880.000.000,00</td>
+                        </tr>
+                    </table>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+</body>
+</html>

--- a/tests/fixtures/pengumuman_lelang.html
+++ b/tests/fixtures/pengumuman_lelang.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html>
+<head><title>Pengumuman Lelang</title></head>
+<body>
+<div class="content">
+    <table class="table table-bordered">
+        <tbody>
+            <tr>
+                <th>Kode Tender</th>
+                <td>10080116000</td>
+            </tr>
+            <tr>
+                <th>Nama Tender</th>
+                <td>Paket Lelang Test 1 <span class="label label-info">Pengadaan Barang</span></td>
+            </tr>
+            <tr>
+                <th>Tanggal Pembuatan</th>
+                <td>15 Januari 2025</td>
+            </tr>
+            <tr>
+                <th>Tahap Tender Saat Ini</th>
+                <td>Tender Sudah Selesai</td>
+            </tr>
+            <tr>
+                <th>K/L/PD</th>
+                <td>KEMENTERIAN KEUANGAN</td>
+            </tr>
+            <tr>
+                <th>Satuan Kerja</td>
+                <td>DIREKTORAT JENDERAL PERBENDAHARAAN</td>
+            </tr>
+            <tr>
+                <th>Jenis Pengadaan</th>
+                <td>Pengadaan Barang</td>
+            </tr>
+            <tr>
+                <th>Metode Pengadaan</th>
+                <td>Tender Terbuka</td>
+            </tr>
+            <tr>
+                <th>Tahun Anggaran</th>
+                <td>2025</td>
+            </tr>
+            <tr>
+                <th>Nilai Pagu Paket</th>
+                <td>Rp 1.000.000.000,00</td>
+            </tr>
+            <tr>
+                <th>Nilai HPS Paket</th>
+                <td>Rp 950.000.000,00</td>
+            </tr>
+            <tr>
+                <th>Jenis Kontrak</th>
+                <td>Lumpsum</td>
+            </tr>
+            <tr>
+                <th>Kualifikasi Usaha</th>
+                <td>Kecil</td>
+            </tr>
+            <tr>
+                <th>Peserta Tender</th>
+                <td>5 Peserta</td>
+            </tr>
+            <tr>
+                <th>Lokasi Pekerjaan</th>
+                <td>
+                    <ul>
+                        <li>Jakarta - DKI Jakarta</li>
+                    </ul>
+                </td>
+            </tr>
+            <tr>
+                <th>Rencana Umum Pengadaan</th>
+                <td>
+                    <table>
+                        <tbody>
+                            <tr>
+                                <th>Kode RUP</th>
+                                <th>Nama Paket</th>
+                            </tr>
+                            <tr>
+                                <td>RUP-001</td>
+                                <td>Paket RUP Test</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+</body>
+</html>

--- a/tests/fixtures/peserta.html
+++ b/tests/fixtures/peserta.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head><title>Peserta Lelang</title></head>
+<body>
+<div class="content">
+    <table class="table">
+        <tr>
+            <th>No</th>
+            <th>Nama Peserta</th>
+            <th>NPWP</th>
+            <th>Harga Penawaran</th>
+        </tr>
+        <tr>
+            <td>1</td>
+            <td>PT. Test Satu</td>
+            <td>01.234.567.8-012.000</td>
+            <td>Rp 900.000.000,00</td>
+        </tr>
+        <tr>
+            <td>2</td>
+            <td>CV. Test Dua</td>
+            <td>02.345.678.9-023.000</td>
+            <td>Rp 920.000.000,00</td>
+        </tr>
+    </table>
+</div>
+</body>
+</html>

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,201 @@
+"""Tests for pyproc.cache.CacheStore."""
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from pyproc.cache import CacheStore
+
+
+class TestCacheStore(unittest.TestCase):
+
+    def _make_store(self):
+        f = tempfile.NamedTemporaryFile(suffix='.idx', delete=False)
+        f.close()
+        return Path(f.name)
+
+    def test_create_schema(self):
+        db_path = self._make_store()
+        try:
+            with CacheStore(db_path) as store:
+                store.create_schema()
+                # Verify table exists
+                result = store.db.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table' AND name='INDEX_PAKET'"
+                ).fetchone()
+                self.assertIsNotNone(result)
+
+                # Verify indexes
+                indexes = store.db.execute(
+                    "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='INDEX_PAKET'"
+                ).fetchall()
+                index_names = [i[0] for i in indexes]
+                self.assertIn('INDEX_PAKET_KATEGORI_TAHUN_ANGGARAN_IDX', index_names)
+                self.assertIn('INDEX_PAKET_STATUS_IDX', index_names)
+        finally:
+            db_path.unlink(missing_ok=True)
+
+    def test_drop_schema(self):
+        db_path = self._make_store()
+        try:
+            with CacheStore(db_path) as store:
+                store.create_schema()
+                store.drop_schema()
+                result = store.db.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table' AND name='INDEX_PAKET'"
+                ).fetchone()
+                self.assertIsNone(result)
+        finally:
+            db_path.unlink(missing_ok=True)
+
+    def test_reset(self):
+        db_path = self._make_store()
+        try:
+            with CacheStore(db_path) as store:
+                store.create_schema()
+                store.insert_rows([('tender-1', '1', 'tender', '2025', 0, None)])
+                self.assertTrue(store.has_rows())
+
+                store.reset()
+                self.assertFalse(store.has_rows())
+        finally:
+            db_path.unlink(missing_ok=True)
+
+    def test_has_rows_empty(self):
+        db_path = self._make_store()
+        try:
+            with CacheStore(db_path) as store:
+                store.create_schema()
+                self.assertFalse(store.has_rows())
+        finally:
+            db_path.unlink(missing_ok=True)
+
+    def test_has_rows_with_data(self):
+        db_path = self._make_store()
+        try:
+            with CacheStore(db_path) as store:
+                store.create_schema()
+                store.insert_rows([('tender-1', '1', 'tender', '2025', 0, None)])
+                self.assertTrue(store.has_rows())
+        finally:
+            db_path.unlink(missing_ok=True)
+
+    def test_insert_and_get_pending(self):
+        db_path = self._make_store()
+        try:
+            with CacheStore(db_path) as store:
+                store.create_schema()
+                store.insert_rows([
+                    ('tender-1', '1', 'tender', '2025', 0, None),
+                    ('tender-2', '2', 'tender', '2025', 0, None),
+                    ('tender-3', '3', 'tender', '2025', 1, '{}'),
+                ])
+
+                pending = list(store.get_pending())
+                self.assertEqual(len(pending), 2)
+                ids = [r['id_paket'] for r in pending]
+                self.assertIn('1', ids)
+                self.assertIn('2', ids)
+                self.assertNotIn('3', ids)
+        finally:
+            db_path.unlink(missing_ok=True)
+
+    def test_insert_or_ignore(self):
+        db_path = self._make_store()
+        try:
+            with CacheStore(db_path) as store:
+                store.create_schema()
+                store.insert_rows([('tender-1', '1', 'tender', '2025', 0, None)])
+                store.insert_rows([('tender-1', '1', 'tender', '2025', 0, None)])
+
+                count = store.db.execute("SELECT COUNT(1) FROM INDEX_PAKET").fetchone()[0]
+                self.assertEqual(count, 1)
+        finally:
+            db_path.unlink(missing_ok=True)
+
+    def test_update_detail(self):
+        db_path = self._make_store()
+        try:
+            with CacheStore(db_path) as store:
+                store.create_schema()
+                store.insert_rows([('tender-1', '1', 'tender', '2025', 0, None)])
+
+                store.update_detail('tender-1', '{"pengumuman": {"kode": "123"}}')
+
+                completed = list(store.get_completed())
+                self.assertEqual(len(completed), 1)
+                self.assertEqual(completed[0]['status'], 1)
+                self.assertIn('pengumuman', json.loads(completed[0]['detail']))
+        finally:
+            db_path.unlink(missing_ok=True)
+
+    def test_get_completed(self):
+        db_path = self._make_store()
+        try:
+            with CacheStore(db_path) as store:
+                store.create_schema()
+                store.insert_rows([
+                    ('tender-1', '1', 'tender', '2025', 1, '{"a": 1}'),
+                    ('tender-2', '2', 'tender', '2025', 0, None),
+                ])
+
+                completed = list(store.get_completed())
+                self.assertEqual(len(completed), 1)
+                self.assertEqual(completed[0]['id_paket'], '1')
+        finally:
+            db_path.unlink(missing_ok=True)
+
+    def test_count_by_status(self):
+        db_path = self._make_store()
+        try:
+            with CacheStore(db_path) as store:
+                store.create_schema()
+                store.insert_rows([
+                    ('tender-1', '1', 'tender', '2025', 0, None),
+                    ('tender-2', '2', 'tender', '2025', 0, None),
+                    ('tender-3', '3', 'tender', '2025', 1, '{}'),
+                    ('tender-4', '4', 'tender', '2025', 1, '{}'),
+                    ('tender-5', '5', 'tender', '2025', 1, '{}'),
+                ])
+
+                counts = store.count_by_status()
+                self.assertEqual(counts[0], 2)
+                self.assertEqual(counts[1], 3)
+        finally:
+            db_path.unlink(missing_ok=True)
+
+    def test_context_manager_closes_connection(self):
+        db_path = self._make_store()
+        try:
+            store = CacheStore(db_path)
+            store.__enter__()
+            store.create_schema()
+            self.assertIsNotNone(store.db)
+            store.__exit__(None, None, None)
+            self.assertIsNone(store.db)
+        finally:
+            db_path.unlink(missing_ok=True)
+
+    def test_close_idempotent(self):
+        db_path = self._make_store()
+        try:
+            with CacheStore(db_path) as store:
+                store.create_schema()
+                store.close()
+                store.close()  # Should not raise
+        finally:
+            db_path.unlink(missing_ok=True)
+
+    def test_has_rows_no_table(self):
+        """has_rows should return False when table doesn't exist."""
+        db_path = self._make_store()
+        try:
+            with CacheStore(db_path) as store:
+                # Don't create schema
+                self.assertFalse(store.has_rows())
+        finally:
+            db_path.unlink(missing_ok=True)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_cli_unit.py
+++ b/tests/test_cli_unit.py
@@ -1,0 +1,525 @@
+"""Mocked unit tests for CLI components — no network required."""
+import csv
+import json
+import os
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from pyproc.cache import CacheStore
+from pyproc.cli import (
+    Downloader, DownloaderContext, LpseHost, LpseIndex,
+    IndexDownloader, Exporter, QualityAssurance,
+)
+from pyproc.exceptions import DownloaderContextException
+
+
+class TestLpseHost(unittest.TestCase):
+
+    def test_parse_host_simple(self):
+        host = LpseHost("kemenkeu")
+        self.assertTrue(host.is_valid)
+        self.assertIsNone(host.error)
+        self.assertEqual(host.url, "kemenkeu")
+        self.assertEqual(host.filename.name, "kemenkeu")
+
+    def test_parse_host_with_filename(self):
+        host = LpseHost("kemenkeu;my_output")
+        self.assertTrue(host.is_valid)
+        self.assertIsNone(host.error)
+        self.assertEqual(host.url, "kemenkeu")
+        self.assertEqual(host.filename.name, "my_output")
+
+    def test_parse_host_url_with_dots(self):
+        host = LpseHost("sumbarprov")
+        self.assertTrue(host.is_valid)
+        self.assertEqual(host.url, "sumbarprov")
+        self.assertEqual(host.filename.name, "sumbarprov")
+
+    def test_parse_host_generates_filename_from_url(self):
+        host = LpseHost("bengkuluprov")
+        self.assertTrue(host.is_valid)
+        self.assertEqual(host.filename.name, "bengkuluprov")
+
+
+class TestDownloaderContext(unittest.TestCase):
+
+    def _make_args(self, **kwargs):
+        """Create a mock args namespace with defaults."""
+        defaults = {
+            'lpse_host': 'kemenkeu',
+            'keyword': '',
+            'tahun_anggaran': '2025',
+            'kategori': None,
+            'nama_penyedia': None,
+            'chunk_size': 100,
+            'workers': 8,
+            'timeout': 30,
+            'non_tender': False,
+            'index_download_delay': 1,
+            'keep_index': False,
+            'log': 'INFO',
+            'output_format': 'csv',
+            'resume': False,
+            'separator': ';',
+        }
+        defaults.update(kwargs)
+        return MagicMock(**defaults)
+
+    def test_basic_context(self):
+        args = self._make_args()
+        ctx = DownloaderContext(args)
+        self.assertEqual(ctx.keyword, '')
+        self.assertEqual(ctx.chunk_size, 100)
+        self.assertEqual(ctx.timeout, 30)
+        self.assertFalse(ctx.non_tender)
+
+    def test_tahun_anggaran_single(self):
+        args = self._make_args(tahun_anggaran='2020')
+        ctx = DownloaderContext(args)
+        self.assertEqual(ctx.tahun_anggaran, [2020])
+
+    def test_tahun_anggaran_multiple(self):
+        args = self._make_args(tahun_anggaran='2020,2021,2022')
+        ctx = DownloaderContext(args)
+        self.assertEqual(ctx.tahun_anggaran, [2020, 2021, 2022])
+
+    def test_tahun_anggaran_range(self):
+        args = self._make_args(tahun_anggaran='2020-2023')
+        ctx = DownloaderContext(args)
+        self.assertEqual(ctx.tahun_anggaran, [2020, 2021, 2022, 2023])
+
+    def test_tahun_anggaran_mixed(self):
+        args = self._make_args(tahun_anggaran='2020-2022,2025')
+        ctx = DownloaderContext(args)
+        self.assertEqual(ctx.tahun_anggaran, [2020, 2021, 2022, 2025])
+
+    def test_tahun_anggaran_all(self):
+        args = self._make_args(tahun_anggaran='all')
+        ctx = DownloaderContext(args)
+        self.assertEqual(ctx.tahun_anggaran, [None])
+
+    def test_tahun_anggaran_invalid_separator(self):
+        args = self._make_args(tahun_anggaran='2020;2021')
+        with self.assertRaises(DownloaderContextException):
+            DownloaderContext(args)
+
+    def test_tahun_anggaran_invalid_range(self):
+        args = self._make_args(tahun_anggaran='1999-2030')
+        with self.assertRaises(DownloaderContextException):
+            DownloaderContext(args)
+
+    def test_kategori_valid(self):
+        args = self._make_args(kategori='PEKERJAAN_KONSTRUKSI')
+        ctx = DownloaderContext(args)
+        from pyproc.lpse import JenisPengadaan
+        self.assertEqual(ctx.kategori, JenisPengadaan.PEKERJAAN_KONSTRUKSI)
+
+    def test_kategori_invalid(self):
+        args = self._make_args(kategori='INVALID')
+        ctx = DownloaderContext(args)
+        self.assertIsNone(ctx.kategori)
+
+    def test_kategori_none(self):
+        args = self._make_args(kategori=None)
+        ctx = DownloaderContext(args)
+        self.assertIsNone(ctx.kategori)
+
+    def test_lpse_host_list_from_arg(self):
+        args = self._make_args(lpse_host='kemenkeu')
+        ctx = DownloaderContext(args)
+        hosts = list(ctx.lpse_host_list)
+        self.assertEqual(len(hosts), 1)
+        self.assertEqual(hosts[0].url, 'kemenkeu')
+
+    def test_lpse_host_list_multiple(self):
+        args = self._make_args(lpse_host='kemenkeu,sumbarprov')
+        ctx = DownloaderContext(args)
+        hosts = list(ctx.lpse_host_list)
+        self.assertEqual(len(hosts), 2)
+        urls = [h.url for h in hosts]
+        self.assertIn('kemenkeu', urls)
+        self.assertIn('sumbarprov', urls)
+
+    def test_lpse_host_list_from_file(self):
+        file_path = Path(__file__).parent / 'supporting_files' / 'list-host.txt'
+        args = self._make_args(lpse_host=str(file_path))
+        ctx = DownloaderContext(args)
+        hosts = list(ctx.lpse_host_list)
+        self.assertEqual(len(hosts), 2)
+        for h in hosts:
+            self.assertTrue(h.is_valid)
+
+
+class TestLpseIndex(unittest.TestCase):
+
+    def test_from_kwargs(self):
+        kwargs = {
+            'row_id': 'tender-10080116000',
+            'id_paket': '10080116000',
+            'jenis_paket': 'tender',
+            'kategori_tahun_anggaran': '2025',
+            'status': 0,
+            'detail': None,
+        }
+        idx = LpseIndex(kwargs)
+        self.assertEqual(idx.row_id, 'tender-10080116000')
+        self.assertEqual(idx.id_paket, '10080116000')
+        self.assertEqual(idx.status, 0)
+        # parse_detail(None) returns None after fix
+        self.assertIsNone(idx.detail)
+
+    def test_from_kwargs_with_detail(self):
+        kwargs = {
+            'row_id': 'tender-10080116000',
+            'id_paket': '10080116000',
+            'jenis_paket': 'tender',
+            'kategori_tahun_anggaran': '2025',
+            'status': 1,
+            'detail': '{"pengumuman": {"kode_tender": "123"}}',
+        }
+        idx = LpseIndex(kwargs)
+        self.assertIsNotNone(idx.detail)
+        self.assertEqual(idx.detail['pengumuman']['kode_tender'], '123')
+
+    def test_parse_detail_valid_json(self):
+        detail_str = '{"pengumuman": {"kode_tender": "123"}}'
+        result = LpseIndex.parse_detail(detail_str)
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result['pengumuman']['kode_tender'], '123')
+
+    def test_parse_detail_none(self):
+        result = LpseIndex.parse_detail(None)
+        self.assertIsNone(result)
+
+    def test_parse_detail_invalid_json(self):
+        result = LpseIndex.parse_detail('not json')
+        self.assertIsNone(result)
+
+
+class TestIndexDownloaderDB(unittest.TestCase):
+
+    def test_create_schema(self):
+        with tempfile.NamedTemporaryFile(suffix='.idx', delete=False) as f:
+            db_path = Path(f.name)
+
+        try:
+            db = sqlite3.connect(str(db_path))
+            db.execute("DROP TABLE IF EXISTS INDEX_PAKET")
+            db.execute("""CREATE TABLE INDEX_PAKET
+            (
+            ROW_ID varchar(100) unique primary key,
+            ID_PAKET VARCHAR(50),
+            JENIS_PAKET VARCHAR(32),
+            KATEGORI_TAHUN_ANGGARAN varchar (100),
+            STATUS int default 0,
+            DETAIL text
+            );""")
+            db.execute("CREATE INDEX INDEX_PAKET_KATEGORI_TAHUN_ANGGARAN_IDX ON INDEX_PAKET(KATEGORI_TAHUN_ANGGARAN);")
+            db.execute("CREATE INDEX INDEX_PAKET_ID_PAKET_IDX ON INDEX_PAKET(ID_PAKET);")
+            db.execute("CREATE INDEX INDEX_PAKET_JENIS_PAKET ON INDEX_PAKET(JENIS_PAKET);")
+            db.execute("CREATE INDEX INDEX_PAKET_STATUS_IDX ON INDEX_PAKET(STATUS);")
+            db.commit()
+
+            # Verify table exists
+            result = db.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='INDEX_PAKET'").fetchone()
+            self.assertIsNotNone(result)
+
+            # Verify indexes
+            indexes = db.execute("SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='INDEX_PAKET'").fetchall()
+            index_names = [i[0] for i in indexes]
+            self.assertIn('INDEX_PAKET_KATEGORI_TAHUN_ANGGARAN_IDX', index_names)
+            self.assertIn('INDEX_PAKET_STATUS_IDX', index_names)
+
+            db.close()
+        finally:
+            db_path.unlink(missing_ok=True)
+
+    def test_insert_and_query(self):
+        with tempfile.NamedTemporaryFile(suffix='.idx', delete=False) as f:
+            db_path = Path(f.name)
+
+        try:
+            db = sqlite3.connect(str(db_path))
+            db.execute("""CREATE TABLE INDEX_PAKET (
+                ROW_ID varchar(100) unique primary key,
+                ID_PAKET VARCHAR(50),
+                JENIS_PAKET VARCHAR(32),
+                KATEGORI_TAHUN_ANGGARAN varchar(100),
+                STATUS int default 0,
+                DETAIL text
+            )""")
+
+            db.execute("INSERT INTO INDEX_PAKET VALUES (?, ?, ?, ?, ?, ?)",
+                       ('tender-100', '100', 'tender', '2025', 0, None))
+            db.execute("INSERT INTO INDEX_PAKET VALUES (?, ?, ?, ?, ?, ?)",
+                       ('tender-200', '200', 'tender', '2025', 1, '{"pengumuman": {}}'))
+            db.commit()
+
+            # Query pending
+            pending = db.execute("SELECT COUNT(1) FROM INDEX_PAKET WHERE STATUS = 0").fetchone()[0]
+            self.assertEqual(pending, 1)
+
+            # Query completed
+            completed = db.execute("SELECT COUNT(1) FROM INDEX_PAKET WHERE STATUS = 1").fetchone()[0]
+            self.assertEqual(completed, 1)
+
+            # Update status
+            db.execute("UPDATE INDEX_PAKET SET STATUS = 1, DETAIL = ? WHERE ROW_ID = ?",
+                       ('{"pengumuman": {}}', 'tender-100'))
+            db.commit()
+
+            pending = db.execute("SELECT COUNT(1) FROM INDEX_PAKET WHERE STATUS = 0").fetchone()[0]
+            self.assertEqual(pending, 0)
+
+            db.close()
+        finally:
+            db_path.unlink(missing_ok=True)
+
+    def test_insert_or_ignore(self):
+        with tempfile.NamedTemporaryFile(suffix='.idx', delete=False) as f:
+            db_path = Path(f.name)
+
+        try:
+            db = sqlite3.connect(str(db_path))
+            db.execute("""CREATE TABLE INDEX_PAKET (
+                ROW_ID varchar(100) unique primary key,
+                ID_PAKET VARCHAR(50),
+                JENIS_PAKET VARCHAR(32),
+                KATEGORI_TAHUN_ANGGARAN varchar(100),
+                STATUS int default 0,
+                DETAIL text
+            )""")
+
+            db.execute("INSERT OR IGNORE INTO INDEX_PAKET VALUES (?, ?, ?, ?, ?, ?)",
+                       ('tender-100', '100', 'tender', '2025', 0, None))
+            db.execute("INSERT OR IGNORE INTO INDEX_PAKET VALUES (?, ?, ?, ?, ?, ?)",
+                       ('tender-100', '100', 'tender', '2025', 0, None))
+            db.commit()
+
+            count = db.execute("SELECT COUNT(1) FROM INDEX_PAKET").fetchone()[0]
+            self.assertEqual(count, 1)
+
+            db.close()
+        finally:
+            db_path.unlink(missing_ok=True)
+
+
+class TestExporter(unittest.TestCase):
+
+    def _create_test_db(self):
+        """Create a temporary SQLite DB with test data using CacheStore."""
+        f = tempfile.NamedTemporaryFile(suffix='.idx', delete=False)
+        f.close()
+        db_path = Path(f.name)
+
+        detail = {
+            'id_paket': '10080116000',
+            'pengumuman': {
+                'nama_tender': 'Test Tender',
+                'tanggal_pembuatan': '15 Januari 2025',
+                'tahap_tender_saat_ini': 'Selesai',
+                'k/l/pd': 'KEMENTERIAN KEUANGAN',
+                'satuan_kerja': 'DJP',
+                'jenis_pengadaan': 'Pengadaan Barang',
+                'metode_pengadaan': 'Tender Terbuka',
+                'tahun_anggaran': '2025',
+                'nilai_pagu_paket': 1000000000,
+                'nilai_hps_paket': 950000000,
+                'jenis_kontrak': 'Lumpsum',
+                'kualifikasi_usaha': 'Kecil',
+                'peserta_tender': 5,
+                'khusus_pelaku_usaha_oap': 'Tidak',
+                'lokasi_pekerjaan': ['Jakarta'],
+                'label_paket': ['Pengadaan Barang'],
+            },
+            'peserta': [{'nama_peserta': 'PT. Test'}],
+            'hasil': [{'nama_peserta': 'PT. Test', 'pemenang': True}],
+            'pemenang': [{'nama_pemenang': 'PT. Test', 'harga_penawaran': 900000000}],
+            'pemenang_berkontrak': None,
+            'jadwal': [{'tahap': 'Evaluasi', 'mulai': '20 Jan 2025'}],
+        }
+
+        with CacheStore(db_path) as store:
+            store.create_schema()
+            store.insert_rows([
+                ('tender-10080116000', '10080116000', 'tender', '2025', 1, json.dumps(detail))
+            ])
+
+        return db_path
+
+    def test_export_csv(self):
+        db_path = self._create_test_db()
+        csv_path = db_path.with_suffix('.csv')
+
+        try:
+            mock_index_downloader = MagicMock()
+            store = CacheStore(db_path)
+            store.__enter__()
+            mock_index_downloader.store = store
+            mock_index_downloader.ctx = MagicMock()
+            mock_index_downloader.ctx.non_tender = False
+
+            mock_host = MagicMock()
+            mock_host.url = 'https://spse.inaproc.id/kemenkeu'
+            mock_host.filename = csv_path.with_suffix('')
+            mock_index_downloader.lpse_host = mock_host
+
+            exporter = Exporter(mock_index_downloader)
+            exporter.get_file_obj = lambda ext: db_path.with_suffix('.' + ext)
+
+            exporter.to_csv(delimiter=';')
+
+            self.assertTrue(csv_path.exists())
+
+            with open(csv_path, 'r', encoding='utf-8') as f:
+                reader = csv.reader(f, delimiter=';')
+                rows = list(reader)
+                self.assertGreater(len(rows), 1)  # header + data
+                self.assertIn('url', rows[0])
+                self.assertIn('id_paket', rows[0])
+
+            store.close()
+        finally:
+            db_path.unlink(missing_ok=True)
+            csv_path.unlink(missing_ok=True)
+
+    def test_export_json(self):
+        db_path = self._create_test_db()
+        json_path = db_path.with_suffix('.json')
+
+        try:
+            mock_index_downloader = MagicMock()
+            store = CacheStore(db_path)
+            store.__enter__()
+            mock_index_downloader.store = store
+            mock_index_downloader.ctx = MagicMock()
+            mock_index_downloader.ctx.non_tender = False
+
+            mock_host = MagicMock()
+            mock_host.url = 'https://spse.inaproc.id/kemenkeu'
+            mock_host.filename = json_path.with_suffix('')
+            mock_index_downloader.lpse_host = mock_host
+
+            exporter = Exporter(mock_index_downloader)
+            exporter.get_file_obj = lambda ext: db_path.with_suffix('.' + ext)
+
+            exporter.to_json()
+
+            self.assertTrue(json_path.exists())
+
+            with open(json_path, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+                self.assertIsInstance(data, list)
+                self.assertEqual(len(data), 1)
+                self.assertIn('pengumuman', data[0])
+
+            store.close()
+        finally:
+            db_path.unlink(missing_ok=True)
+            json_path.unlink(missing_ok=True)
+
+
+class TestQualityAssurance(unittest.TestCase):
+
+    def test_check_counts(self):
+        with tempfile.NamedTemporaryFile(suffix='.idx', delete=False) as f:
+            db_path = Path(f.name)
+
+        try:
+            with CacheStore(db_path) as store:
+                store.create_schema()
+                rows = [(f'tender-{i}', str(i), 'tender', '2025', 1 if i < 5 else 0, None) for i in range(8)]
+                store.insert_rows(rows)
+
+                mock_index_downloader = MagicMock()
+                mock_index_downloader.store = store
+
+                qa = QualityAssurance(mock_index_downloader)
+                total, success, fail = qa.check()
+
+                self.assertEqual(total, 8)
+                self.assertEqual(success, 5)
+                self.assertEqual(fail, 3)
+        finally:
+            db_path.unlink(missing_ok=True)
+
+    def test_check_empty_db(self):
+        with tempfile.NamedTemporaryFile(suffix='.idx', delete=False) as f:
+            db_path = Path(f.name)
+
+        try:
+            with CacheStore(db_path) as store:
+                store.create_schema()
+
+                mock_index_downloader = MagicMock()
+                mock_index_downloader.store = store
+
+                qa = QualityAssurance(mock_index_downloader)
+                total, success, fail = qa.check()
+
+                self.assertEqual(total, 0)
+                self.assertEqual(success, 0)
+                self.assertEqual(fail, 0)
+        finally:
+            db_path.unlink(missing_ok=True)
+
+
+class TestDownloaderGetCtx(unittest.TestCase):
+
+    def test_get_ctx_basic(self):
+        downloader = Downloader()
+        ctx = downloader.get_ctx(['kemenkeu'])
+        self.assertIsNotNone(ctx)
+        self.assertEqual(ctx.keyword, '')
+
+    def test_get_ctx_with_options(self):
+        downloader = Downloader()
+        ctx = downloader.get_ctx([
+            '--keyword', 'sekolah',
+            '--tahun-anggaran', '2025',
+            '--timeout', '60',
+            '--non-tender',
+            'kemenkeu'
+        ])
+        self.assertEqual(ctx.keyword, 'sekolah')
+        self.assertEqual(ctx.tahun_anggaran, [2025])
+        self.assertEqual(ctx.timeout, 60)
+        self.assertTrue(ctx.non_tender)
+
+    def test_get_ctx_kategori_choices(self):
+        downloader = Downloader()
+        ctx = downloader.get_ctx(['--kategori', 'PEKERJAAN_KONSTRUKSI', 'kemenkeu'])
+        from pyproc.lpse import JenisPengadaan
+        self.assertEqual(ctx.kategori, JenisPengadaan.PEKERJAAN_KONSTRUKSI)
+
+    def test_get_ctx_invalid_kategori_exits(self):
+        downloader = Downloader()
+        with self.assertRaises(SystemExit):
+            downloader.get_ctx(['--kategori', 'INVALID', 'kemenkeu'])
+
+    def test_get_ctx_resume_flag(self):
+        downloader = Downloader()
+        ctx = downloader.get_ctx(['--resume', 'kemenkeu'])
+        self.assertTrue(ctx.resume)
+
+    def test_get_ctx_keep_index_flag(self):
+        downloader = Downloader()
+        ctx = downloader.get_ctx(['--keep-index', 'kemenkeu'])
+        self.assertTrue(ctx.keep_index)
+
+    def test_get_ctx_output_format_json(self):
+        downloader = Downloader()
+        ctx = downloader.get_ctx(['--output-format', 'json', 'kemenkeu'])
+        self.assertEqual(ctx.output_format, 'json')
+
+    def test_get_ctx_separator(self):
+        downloader = Downloader()
+        ctx = downloader.get_ctx(['--separator', '|', 'kemenkeu'])
+        self.assertEqual(ctx.separator, '|')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_lpse.py
+++ b/tests/test_lpse.py
@@ -371,7 +371,7 @@ class DownloadHostJsonTest(unittest.TestCase):
         import logging
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            data = pyproc.utils.download_host_json(logging, directory=tmpdir)
+            data = pyproc.utils.download_host_json(directory=tmpdir)
             filepath = os.path.join(tmpdir, 'host.json')
 
             self.assertTrue(os.path.isfile(filepath))
@@ -390,7 +390,7 @@ class DownloadHostJsonTest(unittest.TestCase):
         import logging
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            pyproc.utils.download_host_json(logging, name='custom.json', directory=tmpdir)
+            pyproc.utils.download_host_json(name='custom.json', directory=tmpdir)
             filepath = os.path.join(tmpdir, 'custom.json')
 
             self.assertTrue(os.path.isfile(filepath))
@@ -405,7 +405,7 @@ class DownloadHostJsonTest(unittest.TestCase):
         import logging
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            data = pyproc.utils.download_host_json(logging, directory=tmpdir)
+            data = pyproc.utils.download_host_json(directory=tmpdir)
 
             self.assertIsInstance(data, list)
 

--- a/tests/test_lpse_unit.py
+++ b/tests/test_lpse_unit.py
@@ -1,0 +1,492 @@
+"""Mocked unit tests for pyproc.lpse — no network required."""
+import json
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch, PropertyMock
+
+from pyproc.lpse import (
+    Lpse, LpseDetil, LpseDetilNonTender,
+    LpseDetilPengumumanParser, LpseDetilPesertaParser,
+    LpseDetilHasilEvaluasiParser, LpseDetilPemenangParser,
+    LpseDetilJadwalParser, By, JenisPengadaan,
+)
+from pyproc.exceptions import LpseServerExceptions
+
+FIXTURES = Path(__file__).parent / 'fixtures'
+
+
+def load_fixture(name):
+    return (FIXTURES / name).read_text(encoding='utf-8')
+
+
+def load_fixture_bytes(name):
+    return (FIXTURES / name).read_bytes()
+
+
+def mock_response(text='', status_code=200, url='http://test', json_data=None, cookies=None):
+    """Create a mock requests.Response."""
+    resp = MagicMock()
+    resp.text = text
+    resp.content = text.encode('utf-8') if isinstance(text, str) else text
+    resp.status_code = status_code
+    resp.url = url
+    resp.encoding = 'UTF-8'
+    if json_data is not None:
+        resp.json.return_value = json_data
+    if cookies:
+        resp.cookies = cookies
+    return resp
+
+
+class TestLpseInit(unittest.TestCase):
+
+    def test_url_construction(self):
+        lpse = Lpse("kemenkeu")
+        self.assertEqual(lpse.url, "https://spse.inaproc.id/kemenkeu")
+
+    def test_default_timeout(self):
+        lpse = Lpse("test")
+        self.assertEqual(lpse.timeout, 10)
+
+    def test_custom_timeout(self):
+        lpse = Lpse("test", timeout=30)
+        self.assertEqual(lpse.timeout, 30)
+
+    def test_auth_token_initially_none(self):
+        lpse = Lpse("test")
+        self.assertIsNone(lpse.auth_token)
+
+    def test_verify_default_false(self):
+        lpse = Lpse("test")
+        self.assertFalse(lpse.session.verify)
+
+
+class TestGetAuthToken(unittest.TestCase):
+
+    def test_get_auth_token_from_cookies(self):
+        lpse = Lpse("kemenkeu")
+        # Mock the session directly on the instance
+        lpse.session = MagicMock()
+        lpse.session.cookies.get.return_value = 'someprefix___AT=ABC123TOKEN&suffix'
+        lpse.session.get.return_value = mock_response(text=load_fixture('lelang_page.html'))
+
+        token = lpse.get_auth_token(from_cookies=True)
+        self.assertEqual(token, 'ABC123TOKEN')
+
+    def test_get_auth_token_from_page_js(self):
+        lpse = Lpse("kemenkeu")
+        lpse.session = MagicMock()
+        lpse.session.cookies.get.return_value = ''
+        lpse.session.get.return_value = mock_response(text=load_fixture('lelang_page.html'))
+
+        token = lpse.get_auth_token(from_cookies=False)
+        self.assertEqual(token, 'TESTTOKENABC123XYZ')
+
+
+class TestCheckError(unittest.TestCase):
+
+    def test_no_error_on_200(self):
+        resp = mock_response(text='<html><body>OK</body></html>', status_code=200)
+        # Should not raise
+        Lpse.check_error(resp)
+
+    def test_raises_on_400(self):
+        resp = mock_response(text='Bad Request', status_code=400, url='http://test/url')
+        with self.assertRaises(LpseServerExceptions):
+            Lpse.check_error(resp)
+
+    def test_raises_on_spse_error_text(self):
+        html = '<html><body>Maaf, terjadi error pada aplikasi SPSE.</body></html>'
+        resp = mock_response(text=html, status_code=200, url='http://test/url')
+        with self.assertRaises(LpseServerExceptions):
+            Lpse.check_error(resp)
+
+    def test_raises_on_spse_error_with_code(self):
+        html = '<html><body>Maaf, terjadi error pada aplikasi SPSE. Kode Error: ERR500</body></html>'
+        resp = mock_response(text=html, status_code=200, url='http://test/url')
+        with self.assertRaises(LpseServerExceptions) as ctx:
+            Lpse.check_error(resp)
+        self.assertIn('ERR500', str(ctx.exception))
+
+    def test_raises_on_not_found_text(self):
+        html = '<html><body>Halaman yang dituju tidak ditemukan</body></html>'
+        resp = mock_response(text=html, status_code=200, url='http://test/url')
+        with self.assertRaises(LpseServerExceptions) as ctx:
+            Lpse.check_error(resp)
+        self.assertIn('tidak ditemukan', str(ctx.exception))
+
+    def test_raises_on_terjadi_kesalahan(self):
+        html = '<html><body>Terjadi Kesalahan pada sistem</body></html>'
+        resp = mock_response(text=html, status_code=200, url='http://test/url')
+        with self.assertRaises(LpseServerExceptions):
+            Lpse.check_error(resp)
+
+
+class TestGetPaket(unittest.TestCase):
+
+    def setUp(self):
+        self.lpse = Lpse("kemenkeu")
+        self.lpse.auth_token = 'TEST_TOKEN'
+
+    @patch.object(Lpse, 'check_error')
+    def test_get_paket_returns_dict(self, mock_check_error):
+        json_data = json.loads(load_fixture('dt_lelang.json'))
+        resp = mock_response(json_data=json_data)
+        self.lpse.session.post = MagicMock(return_value=resp)
+
+        result = self.lpse.get_paket('lelang', start=0, length=10)
+
+        self.assertIsInstance(result, dict)
+        self.assertIn('data', result)
+        self.assertIn('recordsTotal', result)
+        self.assertEqual(len(result['data']), 2)
+
+    @patch.object(Lpse, 'check_error')
+    def test_get_paket_data_only_returns_list(self, mock_check_error):
+        json_data = json.loads(load_fixture('dt_lelang.json'))
+        resp = mock_response(json_data=json_data)
+        self.lpse.session.post = MagicMock(return_value=resp)
+
+        result = self.lpse.get_paket('lelang', data_only=True)
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)
+
+    @patch.object(Lpse, 'check_error')
+    def test_get_paket_sends_auth_token(self, mock_check_error):
+        json_data = json.loads(load_fixture('dt_lelang.json'))
+        resp = mock_response(json_data=json_data)
+        self.lpse.session.post = MagicMock(return_value=resp)
+
+        self.lpse.get_paket('lelang')
+
+        call_kwargs = self.lpse.session.post.call_args
+        posted_data = call_kwargs[1]['data'] if 'data' in call_kwargs[1] else call_kwargs[0][1]
+        self.assertEqual(posted_data['authenticityToken'], 'TEST_TOKEN')
+
+    @patch.object(Lpse, 'check_error')
+    def test_get_paket_with_kategori(self, mock_check_error):
+        json_data = json.loads(load_fixture('dt_lelang.json'))
+        resp = mock_response(json_data=json_data)
+        self.lpse.session.post = MagicMock(return_value=resp)
+
+        self.lpse.get_paket('lelang', kategori=JenisPengadaan.PENGADAAN_BARANG)
+
+        call_kwargs = self.lpse.session.post.call_args
+        posted_data = call_kwargs[1]['data'] if 'data' in call_kwargs[1] else call_kwargs[0][1]
+        self.assertEqual(posted_data['kategoriId'], 0)
+
+    @patch.object(Lpse, 'check_error')
+    def test_get_paket_auto_fetches_auth_token(self, mock_check_error):
+        self.lpse.auth_token = None
+        json_data = json.loads(load_fixture('dt_lelang.json'))
+        resp = mock_response(json_data=json_data)
+        # Mock session for both post (get_paket) and get (get_auth_token)
+        self.lpse.session = MagicMock()
+        self.lpse.session.post.return_value = resp
+        self.lpse.session.get.return_value = mock_response(text=load_fixture('lelang_page.html'))
+        self.lpse.session.cookies.get.return_value = ''
+
+        self.lpse.get_paket('lelang')
+
+        self.assertIsNotNone(self.lpse.auth_token)
+
+    def test_get_paket_tender_calls_get_paket(self):
+        self.lpse.get_paket = MagicMock(return_value={'data': []})
+        self.lpse.get_paket_tender(start=0, length=5)
+        self.lpse.get_paket.assert_called_once_with(
+            'lelang', 0, 5, False, None, None, None, By.KODE, None, False, None
+        )
+
+    def test_get_paket_non_tender_calls_get_paket(self):
+        self.lpse.get_paket = MagicMock(return_value={'data': []})
+        self.lpse.get_paket_non_tender(start=0, length=5)
+        self.lpse.get_paket.assert_called_once_with(
+            'pl', 0, 5, False, None, None, None, By.KODE, None, False, None
+        )
+
+    def tearDown(self):
+        del self.lpse
+
+
+class TestDetilPaket(unittest.TestCase):
+
+    def setUp(self):
+        self.lpse = Lpse("kemenkeu")
+
+    def test_detil_paket_tender_returns_lpse_detil(self):
+        detil = self.lpse.detil_paket_tender(10080116000)
+        self.assertIsInstance(detil, LpseDetil)
+        self.assertEqual(detil.id_paket, 10080116000)
+
+    def test_detil_paket_non_tender_returns_lpse_detil_non_tender(self):
+        detil = self.lpse.detil_paket_non_tender(10080116000)
+        self.assertIsInstance(detil, LpseDetilNonTender)
+
+    def test_detil_initial_attributes_are_none(self):
+        detil = self.lpse.detil_paket_tender(10080116000)
+        self.assertIsNone(detil.pengumuman)
+        self.assertIsNone(detil.peserta)
+        self.assertIsNone(detil.hasil)
+        self.assertIsNone(detil.pemenang)
+        self.assertIsNone(detil.pemenang_berkontrak)
+        self.assertIsNone(detil.jadwal)
+
+    def tearDown(self):
+        del self.lpse
+
+
+class TestBaseLpseDetil(unittest.TestCase):
+
+    def setUp(self):
+        self.lpse = Lpse("kemenkeu")
+        self.detil = self.lpse.detil_paket_tender(10080116000)
+
+    def test_todict_excludes_lpse(self):
+        d = self.detil.todict()
+        self.assertNotIn('_lpse', d)
+        self.assertIn('id_paket', d)
+
+    def test_todict_returns_dict(self):
+        d = self.detil.todict()
+        self.assertIsInstance(d, dict)
+
+    def test_todict_called_twice(self):
+        d1 = self.detil.todict()
+        d2 = self.detil.todict()
+        self.assertIsInstance(d1, dict)
+        self.assertIsInstance(d2, dict)
+
+    def test_get_all_detil_returns_error_info(self):
+        # With no network, all detail fetches will fail
+        # But get_all_detil should catch exceptions and return error info
+        info = self.detil.get_all_detil()
+        self.assertIsInstance(info, dict)
+        self.assertIn('error', info)
+        self.assertIn('error_message', info)
+
+    def tearDown(self):
+        del self.lpse
+
+
+class TestPengumumanParser(unittest.TestCase):
+
+    def test_parse_pengumuman(self):
+        content = load_fixture_bytes('pengumuman_lelang.html')
+        lpse = Lpse("kemenkeu")
+        parser = LpseDetilPengumumanParser(lpse, 10080116000)
+        result = parser.parse_detil(content)
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result['kode_tender'], '10080116000')
+        self.assertIn('nama_tender', result)
+        self.assertIn('tahun_anggaran', result)
+        self.assertIn('nilai_pagu_paket', result)
+        self.assertIn('nilai_hps_paket', result)
+        self.assertEqual(result['label_paket'], ['Pengadaan Barang'])
+
+    def test_parse_pengumuman_currency(self):
+        content = load_fixture_bytes('pengumuman_lelang.html')
+        lpse = Lpse("kemenkeu")
+        parser = LpseDetilPengumumanParser(lpse, 10080116000)
+        result = parser.parse_detil(content)
+
+        self.assertIsInstance(result['nilai_pagu_paket'], float)
+        self.assertEqual(result['nilai_pagu_paket'], 1000000000.0)
+        self.assertEqual(result['nilai_hps_paket'], 950000000.0)
+
+    def test_parse_pengumuman_peserta_count(self):
+        content = load_fixture_bytes('pengumuman_lelang.html')
+        lpse = Lpse("kemenkeu")
+        parser = LpseDetilPengumumanParser(lpse, 10080116000)
+        result = parser.parse_detil(content)
+
+        self.assertEqual(result['peserta_tender'], 5)
+
+    def test_parse_pengumuman_lokasi(self):
+        content = load_fixture_bytes('pengumuman_lelang.html')
+        lpse = Lpse("kemenkeu")
+        parser = LpseDetilPengumumanParser(lpse, 10080116000)
+        result = parser.parse_detil(content)
+
+        self.assertIsInstance(result['lokasi_pekerjaan'], list)
+        self.assertIn('Jakarta - DKI Jakarta', result['lokasi_pekerjaan'])
+
+    def test_parse_pengumuman_rup(self):
+        content = load_fixture_bytes('pengumuman_lelang.html')
+        lpse = Lpse("kemenkeu")
+        parser = LpseDetilPengumumanParser(lpse, 10080116000)
+        result = parser.parse_detil(content)
+
+        self.assertIsInstance(result['rencana_umum_pengadaan'], list)
+        self.assertEqual(len(result['rencana_umum_pengadaan']), 1)
+        self.assertEqual(result['rencana_umum_pengadaan'][0]['kode_rup'], 'RUP-001')
+
+
+class TestPesertaParser(unittest.TestCase):
+
+    def test_parse_peserta(self):
+        content = load_fixture_bytes('peserta.html')
+        lpse = Lpse("kemenkeu")
+        parser = LpseDetilPesertaParser(lpse, 10080116000)
+        result = parser.parse_detil(content)
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)
+        self.assertIn('nama_peserta', result[0])
+        self.assertEqual(result[0]['nama_peserta'], 'PT. Test Satu')
+
+
+class TestHasilEvaluasiParser(unittest.TestCase):
+
+    def test_parse_hasil_evaluasi(self):
+        content = load_fixture_bytes('hasil_evaluasi.html')
+        lpse = Lpse("kemenkeu")
+        parser = LpseDetilHasilEvaluasiParser(lpse, 10080116000)
+        result = parser.parse_detil(content)
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)
+
+        # First row: winner (star icon)
+        self.assertTrue(result[0]['pemenang'])
+        self.assertEqual(result[0]['evaluasi_administrasi'], 1)  # fa-check
+        self.assertEqual(result[0]['evaluasi_teknis'], 1)  # fa-check
+
+        # Second row: not winner (fa-minus -> None -> False via parse_children)
+        self.assertFalse(result[1]['pemenang'])
+        self.assertEqual(result[1]['evaluasi_administrasi'], 1)  # fa-check
+        self.assertEqual(result[1]['evaluasi_teknis'], 0)  # fa-close
+
+    def test_parse_hasil_evaluasi_scores(self):
+        content = load_fixture_bytes('hasil_evaluasi.html')
+        lpse = Lpse("kemenkeu")
+        parser = LpseDetilHasilEvaluasiParser(lpse, 10080116000)
+        result = parser.parse_detil(content)
+
+        self.assertEqual(result[0]['skor_teknis'], 85.0)
+        self.assertEqual(result[0]['skor_harga'], 95.0)
+        self.assertEqual(result[0]['skor_akhir'], 90.0)
+
+    def test_parse_hasil_evaluasi_currency(self):
+        content = load_fixture_bytes('hasil_evaluasi.html')
+        lpse = Lpse("kemenkeu")
+        parser = LpseDetilHasilEvaluasiParser(lpse, 10080116000)
+        result = parser.parse_detil(content)
+
+        self.assertEqual(result[0]['penawaran'], 900000000.0)
+        self.assertEqual(result[0]['penawaran_terkoreksi'], 900000000.0)
+        self.assertEqual(result[0]['hasil_negosiasi'], 900000000.0)
+
+    def test_parse_hasil_evaluasi_empty_table(self):
+        lpse = Lpse("kemenkeu")
+        parser = LpseDetilHasilEvaluasiParser(lpse, 10080116000)
+        result = parser.parse_detil(b'<html><body><div class="content"></div></body></html>')
+        self.assertIsNone(result)
+
+
+class TestPemenangParser(unittest.TestCase):
+
+    def test_parse_pemenang(self):
+        content = load_fixture_bytes('pemenang.html')
+        lpse = Lpse("kemenkeu")
+        parser = LpseDetilPemenangParser(lpse, 10080116000)
+        result = parser.parse_detil(content)
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]['nama_pemenang'], 'PT. Test Satu')
+        self.assertEqual(result[0]['alamat'], 'Jl. Test No. 1, Jakarta')
+        self.assertEqual(result[0]['npwp'], '01.234.567.8-012.000')
+
+    def test_parse_pemenang_currency(self):
+        content = load_fixture_bytes('pemenang.html')
+        lpse = Lpse("kemenkeu")
+        parser = LpseDetilPemenangParser(lpse, 10080116000)
+        result = parser.parse_detil(content)
+
+        self.assertEqual(result[0]['harga_penawaran'], 900000000.0)
+        self.assertEqual(result[0]['harga_terkoreksi'], 900000000.0)
+        self.assertEqual(result[0]['hasil_negosiasi'], 880000000.0)
+
+    def test_parse_pemenang_empty_table(self):
+        lpse = Lpse("kemenkeu")
+        parser = LpseDetilPemenangParser(lpse, 10080116000)
+        result = parser.parse_detil(b'<html><body><div class="content"></div></body></html>')
+        self.assertIsNone(result)
+
+    def test_parse_pemenang_all_flag(self):
+        content = load_fixture_bytes('pemenang.html')
+        lpse = Lpse("kemenkeu")
+        parser = LpseDetilPemenangParser(lpse, 10080116000, all=True)
+        result = parser.parse_detil(content)
+
+        self.assertIsInstance(result, list)
+
+
+class TestJadwalParser(unittest.TestCase):
+
+    def test_parse_jadwal(self):
+        content = load_fixture_bytes('jadwal.html')
+        lpse = Lpse("kemenkeu")
+        parser = LpseDetilJadwalParser(lpse, 10080116000)
+        result = parser.parse_detil(content)
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)
+        self.assertIn('tahap', result[0])
+        self.assertIn('mulai', result[0])
+        self.assertIn('sampai', result[0])
+
+    def test_parse_jadwal_empty_table(self):
+        lpse = Lpse("kemenkeu")
+        parser = LpseDetilJadwalParser(lpse, 10080116000)
+        result = parser.parse_detil(b'<html><body></body></html>')
+        self.assertIsNone(result)
+
+
+class TestEnums(unittest.TestCase):
+
+    def test_by_enum_values(self):
+        self.assertEqual(By.KODE.value, 0)
+        self.assertEqual(By.NAMA_PAKET.value, 1)
+        self.assertEqual(By.INSTANSI.value, 2)
+        self.assertEqual(By.HPS.value, 4)
+
+    def test_jenis_pengadaan_enum_values(self):
+        self.assertEqual(JenisPengadaan.PENGADAAN_BARANG.value, 0)
+        self.assertEqual(JenisPengadaan.JASA_KONSULTANSI_BADAN_USAHA_NON_KONSTRUKSI.value, 1)
+        self.assertEqual(JenisPengadaan.PEKERJAAN_KONSTRUKSI.value, 2)
+        self.assertEqual(JenisPengadaan.JASA_LAINNYA.value, 3)
+        self.assertEqual(JenisPengadaan.JASA_KONSULTANSI_PERORANGAN.value, 4)
+        self.assertEqual(JenisPengadaan.JASA_KONSULTANSI_BADAN_USAHA_KONSTRUKSI.value, 5)
+
+    def test_jenis_pengadaan_lookup_by_name(self):
+        self.assertEqual(JenisPengadaan['PENGADAAN_BARANG'], JenisPengadaan.PENGADAAN_BARANG)
+
+    def test_jenis_pengadaan_lookup_invalid(self):
+        with self.assertRaises(KeyError):
+            JenisPengadaan['INVALID_CATEGORY']
+
+
+class TestCurrencyParser(unittest.TestCase):
+
+    def test_parse_currency_rupiah(self):
+        from pyproc.lpse import BaseLpseDetilParser
+        self.assertEqual(BaseLpseDetilParser.parse_currency('Rp 1.000.000.000,00'), 1000000000.0)
+
+    def test_parse_currency_no_prefix(self):
+        from pyproc.lpse import BaseLpseDetilParser
+        self.assertEqual(BaseLpseDetilParser.parse_currency('500.000,00'), 500000.0)
+
+    def test_parse_currency_empty(self):
+        from pyproc.lpse import BaseLpseDetilParser
+        self.assertEqual(BaseLpseDetilParser.parse_currency(''), 0)
+
+    def test_parse_currency_invalid(self):
+        from pyproc.lpse import BaseLpseDetilParser
+        self.assertEqual(BaseLpseDetilParser.parse_currency('abc'), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Extract SQLite cache logic into pyproc/cache.py (CacheStore class)
- Add 102 mocked unit tests (no network required)
- Add test fixtures with captured SPSE HTML/JSON responses
- Add context manager support to Lpse and CacheStore
- Add verify parameter to Lpse for SSL config
- Add type hints to public API methods
- Fix LpseIndex.parse_detail() inconsistent return type
- Fix pyproject.toml Python version classifiers
- Hide misleading --workers argument from help
- Move InsecureRequestWarning suppression to API layer
- Clean up utils.py: use logging.getLogger instead of passed param
- Convert main() to support subcommands with backward compat
- Add test and release CI workflows